### PR TITLE
refactor(web-app): Update implementation to use projen

### DIFF
--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -65,7 +65,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.28",
+  "version": "0.0.37",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -1,14 +1,13 @@
-import { Environment, EnvironmentDefinition } from '@caws-blueprint-component/caws-environments';
 import { SourceRepository } from '@caws-blueprint-component/caws-source-repositories';
-import { Workflow, WorkflowDefinition } from '@caws-blueprint-component/caws-workflows';
 import { SampleWorkspaces, Workspace } from '@caws-blueprint-component/caws-workspaces';
-import {
-  Blueprint as ParentBlueprint,
-  Options as ParentOptions,
-} from '@caws-blueprint/caws.blueprint';
-import { java, web } from 'projen';
+import { Blueprint as ParentBlueprint, Options as ParentOptions } from '@caws-blueprint/caws.blueprint';
+import { awscdk, AwsCdkTypeScriptApp, Project, SourceCode, web } from 'projen';
 
 import defaults from './defaults.json';
+import { helloWorldLambdaCallback } from './hello-world-lambda';
+import { createLambda } from './lambda-generator';
+import { getStackDefinition, getStackTestDefintion } from './stack';
+import { createClass } from './stack-generator';
 
 /**
  * This is the 'Options' interface. The 'Options' interface is interpreted by the wizard to dynamically generate a selection UI.
@@ -18,70 +17,61 @@ import defaults from './defaults.json';
  */
 export interface Options extends ParentOptions {
   /**
-   * The name of the application
-   */
+     * The name of the application.
+     */
   name: string;
-
   /**
-   * Enivroments to deploy into.
-   */
-  environments: EnvironmentDefinition[];
-
-  /**
-   * Options for the Frontend Application
-   */
+     * Options for the Frontend Application
+     */
   frontend: {
     /**
-     * The name of the Frontend Application
-     */
+         * The name of the Frontend Application
+         */
     name: string;
-
     /**
-     * The relative path of the Frontend Application
-     * @advanced
-     */
+         * The relative path of the Frontend Application
+         * @advanced
+         */
     outdir: string;
-
     /**
-     * The license of the Frontend Application
-     */
+         * The license of the Frontend Application
+         * See https://github.com/projen/projen/tree/main/license-text
+         */
     license?: 'MIT' | 'Apache-2.0';
   };
-
   backend: {
     /**
-     * The name of the Backend Application
-     */
+         * The name of the Backend Application
+         */
     name: string;
-
     /**
-     * The relative path of the Backend Application
-     * @advanced
-     */
+         * The relative path of the Backend Application
+         * @advanced
+         */
     outdir: string;
-
     /**
-     * The artifactId of the backend java application
-     */
-    artifactId: string;
-
-    /**
-     * The groupId of the backend java Application
-     */
-    groupId: string;
+         * The license of the Backend Application
+         * See https://github.com/projen/projen/tree/main/license-text
+         */
+    license?: 'MIT' | 'Apache-2.0';
   };
   /**
-   * Specify the contents of the repository README.md
-   * @input textarea
-   * @advanced
-   */
-  readme: string;
-
-  /**
-   * Specifies the default release branch
-   * @advanced
-   */
+     * Specifies the default release branch
+     * @advanced
+     */
   defaultReleaseBranch: string;
+  /**
+     * AWS Account ID
+     */
+  awsAccountId: string;
+  /**
+     * awsRegion
+     */
+  awsRegion: string;
+  /**
+     * S3 Bucket that will host the React Web App
+     */
+  s3BucketName: string;
 }
 
 /**
@@ -90,127 +80,84 @@ export interface Options extends ParentOptions {
  * 2. This Blueprint should extend another ParentBlueprint
  */
 export class Blueprint extends ParentBlueprint {
-  private readonly frontendRepository: SourceRepository;
-  private readonly backendRepository: SourceRepository;
+  protected options: Options;
 
   constructor(options_: Options) {
     super(options_);
     const options = Object.assign(defaults, options_);
+    this.options = options;
 
-    options.environments.forEach(envDef => {
-      new Environment(this, envDef);
+    const repository = new SourceRepository(this, {
+      title: this.options.name,
     });
+    new Workspace(this, repository, SampleWorkspaces.default);
 
-    this.frontendRepository = new SourceRepository(this, {
-      title: options.frontend.name,
-    });
-
-    new web.ReactTypeScriptProject({
-      outdir: this.frontendRepository.relativePath,
-      parent: this,
-      name: options.frontend.outdir,
-      authorEmail: 'caws@amazon.com',
-      authorName: 'codeaws',
-      defaultReleaseBranch: options.defaultReleaseBranch,
-      license: options.frontend.license,
-    });
-
-    this.backendRepository = new SourceRepository(this, {
-      title: options.backend.name,
-    });
-
-    new Workspace(this, this.backendRepository, SampleWorkspaces.default);
-
-    new java.JavaProject({
-      outdir: this.backendRepository.relativePath,
-      parent: this,
-      name: options.backend.name,
-      groupId: options.backend.groupId,
-      artifactId: options.backend.artifactId,
-      version: '1.0.0',
-    });
-
-    new Workflow(
-      this,
-      this.frontendRepository,
-      this.createWorkflowDefintion({
-        branch: options.defaultReleaseBranch,
-        ActionRoleArn: 'MY_ACTION_ROLE_ARN',
-        S3_BUCKET: 'MY_S3_BUCKET_VAR_VALUE',
-        CodeAwsRoleARN: 'MY_CAWS_ROLE_ARN',
-        StackRoleARN: 'MY_STACK_ROLE_ARN',
-      }),
-    );
-
-    new Workflow(
-      this,
-      this.backendRepository,
-      this.createWorkflowDefintion({
-        branch: options.defaultReleaseBranch,
-        ActionRoleArn: 'MY_ACTION_ROLE_ARN',
-        S3_BUCKET: 'MY_S3_BUCKET_VAR_VALUE',
-        CodeAwsRoleARN: 'MY_CAWS_ROLE_ARN',
-        StackRoleARN: 'MY_STACK_ROLE_ARN',
-      }),
-    );
+    this.createFrontend(this, repository);
+    this.createStacks(this, repository);
   }
 
-  protected createWorkflowDefintion(options: {
-    branch: string;
-    ActionRoleArn: string;
-    S3_BUCKET: string;
-    CodeAwsRoleARN: string;
-    StackRoleARN: string;
-  }): WorkflowDefinition {
-    return {
-      Name: 'release',
-      Triggers: [
-        {
-          Type: 'Push',
-          Branches: [options.branch],
-        },
+  private createFrontend(parent: Project, repo: SourceRepository): web.ReactTypeScriptProject {
+    const project = new web.ReactTypeScriptProject({
+      parent,
+      name: `${this.options.frontend.name}`,
+      authorEmail: 'caws@amazon.com',
+      authorName: 'codeaws',
+      outdir: `${repo.relativePath}/${this.options.frontend.outdir}`,
+      defaultReleaseBranch: this.options.defaultReleaseBranch,
+      license: this.options.frontend.license,
+    });
+
+    // Issue: NPM build crawls up the dependency tree and sees a conflicting version of eslint
+    //  that is incompatible with create-react-app (i.e react=scripts). We skip the preflight check
+    //  to prevent blocking warnings.
+    const dotenvFile = new SourceCode(project, '.env');
+    dotenvFile.line('SKIP_PREFLIGHT_CHECK=true');
+
+    return project;
+  }
+
+  private createStacks(parent: Project, repo: SourceRepository): Project {
+    const project = new AwsCdkTypeScriptApp({
+      parent,
+      cdkVersion: '1.95.2',
+      name: `${this.options.backend.name}`,
+      authorEmail: 'caws@amazon.com',
+      authorName: 'codeaws',
+      outdir: `${repo.relativePath}/${this.options.backend.outdir}`,
+      appEntrypoint: 'main.ts',
+      defaultReleaseBranch: this.options.defaultReleaseBranch,
+      cdkDependencies: [
+        '@aws-cdk/core',
+        '@aws-cdk/aws-lambda',
+        '@aws-cdk/aws-apigateway',
+        '@aws-cdk/aws-s3',
+        '@aws-cdk/aws-s3-deployment',
+        '@aws-cdk/aws-cloudfront',
       ],
-      Actions: {
-        BuildBackend: {
-          Identifier: 'aws/build@v1',
-          OutputArtifacts: ['buildArtifact'],
-          Configuration: {
-            ActionRoleArn: options.ActionRoleArn,
-            Variables: [
-              {
-                Name: 'S3_BUCKET',
-                Value: options.S3_BUCKET,
-              },
-            ],
-            Steps: [
-              {
-                Run: 'sam build',
-              },
-              {
-                Run: 'sam package --template-file .aws-sam/build/template.yaml --s3-bucket $S3_BUCKET --output-template-file template-packaged.yaml --region us-west-2',
-              },
-            ],
-            Artifacts: [
-              {
-                Name: 'buildArtifact',
-                Files: ['template-packaged.yaml'],
-              },
-            ],
-          },
-        },
-      },
-      DeployCloudFormationStack: {
-        DependsOn: ['buildArtifact'],
-        Identifier: 'aws/cloudformation-deploy@v1',
-        InputArtifacts: ['BuildArtifact'],
-        Configuration: {
-          CodeAwsRoleARN: options.CodeAwsRoleARN,
-          StackRoleARN: options.StackRoleARN,
-          StackName: 'serverless-api-stack',
-          StackRegion: 'us-west-2',
-          TemplatePath: 'buildArtifact::template-packaged.yaml',
-        },
-      },
-    };
+      sampleCode: false,
+      lambdaAutoDiscover: true,
+      license: this.options.frontend.license,
+    });
+
+    const lambdaName = `${this.options.name}Lambda`;
+    const lambdaOptions: awscdk.LambdaFunctionOptions = createLambda(project, lambdaName, helloWorldLambdaCallback);
+
+    const stackName = `${this.options.name}Stack`;
+    const s3BucketName = this.getUniqueS3BucketName(this.options.s3BucketName);
+    const sourceCode = getStackDefinition(stackName, s3BucketName, this.options, lambdaOptions);
+    createClass(project.outdir, project.srcdir, 'main.ts', sourceCode);
+
+    const testCode = getStackTestDefintion(project.appEntrypoint, stackName);
+    createClass(project.outdir, project.testdir, 'main.test.ts', testCode);
+
+    return project;
+  }
+
+  private getUniqueS3BucketName(s3BucketName: string) {
+    return `${s3BucketName.toLowerCase()}-${this.getSecondSinceEpoch()}`;
+  }
+
+  private getSecondSinceEpoch() {
+    return Math.floor(Date.now() / 1000);
   }
 }

--- a/packages/blueprints/web-app/src/defaults.json
+++ b/packages/blueprints/web-app/src/defaults.json
@@ -1,19 +1,17 @@
 {
-    "name": "web",
-    "environments": [{
-        "title": "Prod",
-        "description": "This is the production environment that your web application gets deployed into."
-    }],
+    "name": "HelloWorldWebApp",
     "frontend": {
         "name": "client",
-        "outdir": "client"
+        "outdir": "client",
+        "license": "MIT"
     },
     "backend": {
         "name": "api",
         "outdir": "api",
-        "artifactId": "com.acme.api",
-        "groupId": "acme"
+        "license": "MIT"
     },
-    "defaultReleaseBranch": "mainline",
-    "readme": "# Web Application"
+    "defaultReleaseBranch": "main",
+    "awsAccountId": "012345678910",
+    "awsRegion": "us-west-2",
+    "s3BucketName": "defaultS3Bucket"
 }

--- a/packages/blueprints/web-app/src/hello-world-lambda.ts
+++ b/packages/blueprints/web-app/src/hello-world-lambda.ts
@@ -1,0 +1,6 @@
+export function helloWorldLambdaCallback(): any {
+  return {
+    statusCode: 200,
+    body: 'hello world',
+  };
+};

--- a/packages/blueprints/web-app/src/lambda-generator.ts
+++ b/packages/blueprints/web-app/src/lambda-generator.ts
@@ -1,0 +1,28 @@
+import { SourceCode, TypeScriptAppProject, awscdk } from 'projen';
+
+/**
+ * @param project
+ * @param functionName - name of the lambda function
+ * @param callback - the body of the lambda function
+ *
+ * @returns
+ */
+export function createLambda(project: TypeScriptAppProject, functionName: string, callback: Function): awscdk.LambdaFunctionOptions {
+  const options: awscdk.LambdaFunctionOptions = {
+    entrypoint: `${project.srcdir}/${functionName}.lambda.ts`,
+    constructFile: `${project.srcdir}/${getConstructFileName(functionName)}.ts`,
+    constructName: `${functionName}Function`,
+  };
+
+  const sourceCode = new SourceCode(project, options.entrypoint);
+  sourceCode.open('exports.handler = async (event: any, context: any) => {');
+  sourceCode.line(`return (${callback.toString()})()`);
+  sourceCode.close('};');
+
+  new awscdk.LambdaFunction(project, options);
+  return options;
+};
+
+export function getConstructFileName(functionName: string) {
+  return `${functionName}-function`;
+}

--- a/packages/blueprints/web-app/src/stack-generator.ts
+++ b/packages/blueprints/web-app/src/stack-generator.ts
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function createClass(outdir: string, srcdir: string, filename: string, sourceCode: string) {
+  const sourceDirectory = path.join(outdir, srcdir);
+  fs.mkdirSync(sourceDirectory, { recursive: true });
+  fs.writeFileSync(path.join(sourceDirectory, filename), sourceCode);
+}

--- a/packages/blueprints/web-app/src/stack.ts
+++ b/packages/blueprints/web-app/src/stack.ts
@@ -1,0 +1,85 @@
+import { basename } from 'path';
+import { awscdk } from 'projen';
+import { Options } from './blueprint';
+
+const TYPESCRIPT_EXT = '.ts';
+
+export function getStackDefinition(stackName: string, s3BucketName: string, blueprintOptions: Options, lambdaOptions: awscdk.LambdaFunctionOptions) {
+  return `import { App, Construct, Stack, StackProps, CfnOutput } from '@aws-cdk/core';
+import * as apigateway from '@aws-cdk/aws-apigateway';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as s3deploy from '@aws-cdk/aws-s3-deployment';
+import * as cloudfront from '@aws-cdk/aws-cloudfront';
+
+import { ${lambdaOptions.constructName} } from './${basename(lambdaOptions.constructFile!, TYPESCRIPT_EXT )}';
+
+export class ${stackName} extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props);
+    const mySiteBucket = new s3.Bucket(this, \'${blueprintOptions.s3BucketName}\', {
+      bucketName: \'${s3BucketName}\',
+      websiteIndexDocument: \'index.html\',
+      publicReadAccess: false,
+    });
+
+    const originAccessIdentity = new cloudfront.OriginAccessIdentity(
+      this,
+      \'${stackName}OriginAccessIdentity\'
+    );
+    mySiteBucket.grantRead(originAccessIdentity);
+
+    new s3deploy.BucketDeployment(this, \'ReactApp\', {
+      sources: [s3deploy.Source.asset(\'./../${blueprintOptions.frontend.outdir}/build\')],
+      destinationBucket: mySiteBucket
+    });
+
+    const distribution = new cloudfront.CloudFrontWebDistribution(this, \'distributionCDN\', {
+      originConfigs: [
+        {
+          s3OriginSource: {
+            s3BucketSource: mySiteBucket,
+            originAccessIdentity,
+          },
+          behaviors: [{ isDefaultBehavior: true }],
+        }
+      ],
+    });
+
+    const handler = new ${lambdaOptions.constructName}(this, \'${lambdaOptions.constructName}\');
+    new apigateway.LambdaRestApi(this, \'${stackName}ApiGateway\', {
+      restApiName: \'${stackName}ApiGateway\',
+      handler,
+      description: \'API gateway for ${stackName}\',
+    });
+
+    new CfnOutput(this, \'Bucket\', { value: mySiteBucket.bucketName });
+    new CfnOutput(this, \'CloudFront URL\', { value: \`https://\$\{distribution.distributionDomainName\}\` });
+  }
+}
+
+const devEnv = {
+  account: \'${blueprintOptions.awsAccountId}\',
+  region: \'${blueprintOptions.awsRegion}\',
+};
+
+const app = new App();
+
+new ${stackName}(app, \'${stackName}\', { env: devEnv });
+
+app.synth();
+`;
+}
+
+export function getStackTestDefintion(appEntrypoint: string, stackName: string) {
+  return `import { App } from \'@aws-cdk/core\';
+import '@aws-cdk/assert/jest';
+import { ${stackName} } from '../src/${basename(appEntrypoint, TYPESCRIPT_EXT)}';
+
+ test('Snapshot', () => {
+   const app = new App();
+   const stack = new ${stackName}(app, 'test', { env: { account: '123', region: 'us-west-2' } });
+
+   expect(app.synth().getStackArtifact(stack.artifactId).template).toMatchSnapshot();
+ });
+`;
+}


### PR DESCRIPTION
### Description

In this PR, we refactor the web-app blueprint to use primarily `projen` to produce a React Web App that is served through S3 Cloudfront and a backend HelloWorldApp that is hosted on a Lambda.

### Testing
* `yarn blueprint:synth`
* `yarn blueprint:publish`
* Deployed to my personal AWS account using the aws-cdk cli.

### Additional context

This is part 1 of (probably) 2. In the future iterations, we'll need to hook this with workflows so that a user doesn't need to clone the synth'd repository locally and run the cdk commands to deploy to an AWS account.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
