### PR TITLE
refactor(web-app): Update implementation to use cdk

### DIFF
--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -65,7 +65,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.28",
+  "version": "0.0.42",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/src/defaults.json
+++ b/packages/blueprints/web-app/src/defaults.json
@@ -1,19 +1,18 @@
 {
-    "name": "web",
-    "environments": [{
-        "title": "Prod",
-        "description": "This is the production environment that your web application gets deployed into."
-    }],
-    "frontend": {
-        "name": "client",
-        "outdir": "client"
-    },
-    "backend": {
-        "name": "api",
-        "outdir": "api",
-        "artifactId": "com.acme.api",
-        "groupId": "acme"
-    },
-    "defaultReleaseBranch": "mainline",
-    "readme": "# Web Application"
+  "name": "HelloWorldWebApp",
+  "frontend": {
+    "name": "client",
+    "outdir": "client",
+    "license": "MIT",
+    "s3BucketName": "REPLACE-ME-REACT-APP-BUCKET-NAME"
+  },
+  "backend": {
+    "name": "api",
+    "outdir": "api",
+    "license": "MIT"
+  },
+  "defaultReleaseBranch": "main",
+  "awsAccountId": "012345678910",
+  "awsRegion": "us-west-2",
+  "buildDeployAndStackRoleArn": "REPLACE_ME_BUILD_ARN"
 }

--- a/packages/blueprints/web-app/src/hello-world-lambda.ts
+++ b/packages/blueprints/web-app/src/hello-world-lambda.ts
@@ -1,0 +1,6 @@
+export function helloWorldLambdaCallback(): any {
+  return {
+    statusCode: 200,
+    body: 'hello world',
+  };
+};

--- a/packages/blueprints/web-app/src/lambda-generator.ts
+++ b/packages/blueprints/web-app/src/lambda-generator.ts
@@ -1,0 +1,28 @@
+import { SourceCode, TypeScriptAppProject, awscdk } from 'projen';
+
+/**
+ * @param project
+ * @param functionName - name of the lambda function
+ * @param callback - the body of the lambda function
+ *
+ * @returns
+ */
+export function createLambda(project: TypeScriptAppProject, functionName: string, callback: Function): awscdk.LambdaFunctionOptions {
+  const options: awscdk.LambdaFunctionOptions = {
+    entrypoint: `${project.srcdir}/${functionName}.lambda.ts`,
+    constructFile: `${project.srcdir}/${getConstructFileName(functionName)}.ts`,
+    constructName: `${functionName}Function`,
+  };
+
+  const sourceCode = new SourceCode(project, options.entrypoint);
+  sourceCode.open('exports.handler = async (event: any, context: any) => {');
+  sourceCode.line(`return (${callback.toString()})()`);
+  sourceCode.close('};');
+
+  new awscdk.LambdaFunction(project, options);
+  return options;
+};
+
+export function getConstructFileName(functionName: string) {
+  return `${functionName}-function`;
+}

--- a/packages/blueprints/web-app/src/stack-generator.ts
+++ b/packages/blueprints/web-app/src/stack-generator.ts
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function createClass(outdir: string, srcdir: string, filename: string, sourceCode: string) {
+  const sourceDirectory = path.join(outdir, srcdir);
+  fs.mkdirSync(sourceDirectory, { recursive: true });
+  fs.writeFileSync(path.join(sourceDirectory, filename), sourceCode);
+}

--- a/packages/blueprints/web-app/src/stack.ts
+++ b/packages/blueprints/web-app/src/stack.ts
@@ -1,0 +1,85 @@
+import { basename } from 'path';
+import { awscdk } from 'projen';
+import { Options } from './blueprint';
+
+const TYPESCRIPT_EXT = '.ts';
+
+export function getStackDefinition(stackName: string, s3BucketName: string, blueprintOptions: Options, lambdaOptions: awscdk.LambdaFunctionOptions) {
+  return `import { App, Construct, Stack, StackProps, CfnOutput } from '@aws-cdk/core';
+import * as apigateway from '@aws-cdk/aws-apigateway';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as s3deploy from '@aws-cdk/aws-s3-deployment';
+import * as cloudfront from '@aws-cdk/aws-cloudfront';
+
+import { ${lambdaOptions.constructName} } from './${basename(lambdaOptions.constructFile!, TYPESCRIPT_EXT )}';
+
+export class ${stackName} extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props);
+    const mySiteBucket = new s3.Bucket(this, \'${s3BucketName}\', {
+      bucketName: \'${s3BucketName}\',
+      websiteIndexDocument: \'index.html\',
+      publicReadAccess: false,
+    });
+
+    const originAccessIdentity = new cloudfront.OriginAccessIdentity(
+      this,
+      \'${stackName}OriginAccessIdentity\'
+    );
+    mySiteBucket.grantRead(originAccessIdentity);
+
+    new s3deploy.BucketDeployment(this, \'ReactApp\', {
+      sources: [s3deploy.Source.asset(\'./../${blueprintOptions.frontend.outdir}/build\')],
+      destinationBucket: mySiteBucket
+    });
+
+    const distribution = new cloudfront.CloudFrontWebDistribution(this, \'distributionCDN\', {
+      originConfigs: [
+        {
+          s3OriginSource: {
+            s3BucketSource: mySiteBucket,
+            originAccessIdentity,
+          },
+          behaviors: [{ isDefaultBehavior: true }],
+        }
+      ],
+    });
+
+    const handler = new ${lambdaOptions.constructName}(this, \'${lambdaOptions.constructName}\');
+    new apigateway.LambdaRestApi(this, \'${stackName}ApiGateway\', {
+      restApiName: \'${stackName}ApiGateway\',
+      handler,
+      description: \'API gateway for ${stackName}\',
+    });
+
+    new CfnOutput(this, \'Bucket\', { value: mySiteBucket.bucketName });
+    new CfnOutput(this, \'CloudFront URL\', { value: \`https://\$\{distribution.distributionDomainName\}\` });
+  }
+}
+
+const devEnv = {
+  account: \'${blueprintOptions.awsAccountId}\',
+  region: \'${blueprintOptions.awsRegion}\',
+};
+
+const app = new App();
+
+new ${stackName}(app, \'${stackName}\', { env: devEnv });
+
+app.synth();
+`;
+}
+
+export function getStackTestDefintion(appEntrypoint: string, stackName: string) {
+  return `import { App } from \'@aws-cdk/core\';
+import '@aws-cdk/assert/jest';
+import { ${stackName} } from '../src/${basename(appEntrypoint, TYPESCRIPT_EXT)}';
+
+ test('Snapshot', () => {
+   const app = new App();
+   const stack = new ${stackName}(app, 'test', { env: { account: '123', region: 'us-west-2' } });
+
+   expect(app.synth().getStackArtifact(stack.artifactId).template).toMatchSnapshot();
+ });
+`;
+}


### PR DESCRIPTION
### Description

* This is a refactor of the existing web app blueprint to use cdk instead of sam. It creates a React Web App that is served through an S3-backed CloudFront URL with a Lambda backend that returns "Hello World".  

### Testing
* `yarn blueprint:synth`.
* `yarn blueprint:publish`.
* Manually tested in the wizard.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
