### PR TITLE
fix(workspaces): rename devfile, update image to public ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,25 @@ yarn build
 ```
 
 You're done!
+
+## Testing Changes
+
+Modify a component
+```
+cd packages/components/<component>
+```
+
+Rebuild the component
+```
+yarn build
+```
+
+To see the changes applied in a blueprint run synth
+```
+cd packages/blueprints/<blueprint>
+yarn blueprint:synth
+```
+This generates the blueprint in the `synth` folder
+```
+packages/blueprints/<blueprint>/synth/<timestamp>
+```

--- a/packages/components/caws-workspaces/src/index.ts
+++ b/packages/components/caws-workspaces/src/index.ts
@@ -17,10 +17,11 @@ export class Workspace extends Component {
   ) {
     super(blueprint);
 
-    new YamlFile(blueprint, path.join(sourceRepository.relativePath, '.mde.devfile.yaml'), {
+    new YamlFile(blueprint, path.join(sourceRepository.relativePath, 'devfile.yaml'), {
       obj: {
         ...workspace,
       },
+      marker: false,
     });
   }
 }

--- a/packages/components/caws-workspaces/src/samples/index.ts
+++ b/packages/components/caws-workspaces/src/samples/index.ts
@@ -15,8 +15,7 @@ export class SampleWorkspaces {
       {
         name: 'aws-runtime',
         container: {
-          image:
-            'image: 012802407964.dkr.ecr.us-west-2.amazonaws.com/barsecrrepo-2a53e09ae3b25e5624c746d11fe76a3d2f1df790:live_universal_100',
+          image: 'public.ecr.aws/d8s8g4g8/a893fn7923fnoe:latest',
           mountSources: true,
         },
       },


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement? Explain your changes.

- fix copy and paste bug for `image` in sample devfile
- rename `.mde.devfile.yaml` to `devfile.yaml`, complying to the devfile standard
- remove generate marker for now, as the projen file is not visible in the repo

### Testing

How was this change tested?

- As described in the added part of the readme
    ```
    yarn blueprint:synth
    ```
- Generating the file `packages/blueprints/lambda-python/synth/16395520988/src/myfirstlambda/devfile.yaml`
    ```
    
    schemaVersion: 2.0.0
    metadata:
      name: aws-universal
      version: 1.0.1
      displayName: AWS Universal
      description: Stack with AWS Universal Tooling
      tags:
        - aws
        - a12
      projectType: aws
    components:
      - name: aws-runtime
        container:
          image: public.ecr.aws/d8s8g4g8/a893fn7923fnoe:latest
          mountSources: true
    ```

### Additional context

Add any other context about the PR here.

- `public.ecr.aws/d8s8g4g8/a893fn7923fnoe:latest` is a temporary url. Will update to the official repo once available.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
