### PR TITLE
feat(workspaces): use public ECR aws-mde/universal-image in sample devfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ install.
 
 ```
 # set project config
- export NPM_REPO=`aws codeartifact get-repository-endpoint --domain template --domain-owner 721779663932 --repository global-templates --format npm | jq -r '.repositoryEndpoint'`
+ export NPM_REPO=`aws codeartifact get-repository-endpoint --region us-west-2 --domain template --domain-owner 721779663932 --repository global-templates --format npm | jq -r '.repositoryEndpoint'`
  echo 'NPM_REPO set to: '$NPM_REPO
- export NPM_REPO_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain template --domain-owner 721779663932 --query authorizationToken --output text`
+ export NPM_REPO_AUTH_TOKEN=`aws codeartifact get-authorization-token --region us-west-2 --domain template --domain-owner 721779663932 --query authorizationToken --output text`
 
  # Set NPM config to also be the same repository (needed for some synths to work properly)
- aws codeartifact login --tool npm --repository global-templates --domain template --domain-owner 721779663932
+ aws codeartifact login --region us-west-2 --tool npm --repository global-templates --domain template --domain-owner 721779663932
 ```
 
 Disable Projen post. Projen doesnt play very well with workspaces just yet. We need to disable

--- a/packages/components/caws-workspaces/src/samples/index.ts
+++ b/packages/components/caws-workspaces/src/samples/index.ts
@@ -15,7 +15,7 @@ export class SampleWorkspaces {
       {
         name: 'aws-runtime',
         container: {
-          image: 'public.ecr.aws/d8s8g4g8/a893fn7923fnoe:latest',
+          image: 'public.ecr.aws/aws-mde/universal-image:latest',
           mountSources: true,
         },
       },


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

- Adding the region to the AWS commands to configure the npm repo so that devs are not required to set the region via `aws configure`.
- Configure the MDE universal image in the generated devfile for blueprints

### Testing

Generated the `lambda-python` blueprint via
```
yarn blueprint:synth
```

Result
```

schemaVersion: 2.0.0
metadata:
  name: aws-universal
  version: 1.0.1
  displayName: AWS Universal
  description: Stack with AWS Universal Tooling
  tags:
    - aws
    - a12
  projectType: aws
components:
  - name: aws-runtime
    container:
      image: public.ecr.aws/aws-mde/universal-image:latest
      mountSources: true
```

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
