### PR TITLE
feat(blueprint-cli): multi-environment publishing support 

### DIFF
--- a/packages/utils/blueprint-cli/src/index.ts
+++ b/packages/utils/blueprint-cli/src/index.ts
@@ -8,6 +8,7 @@ import { AstOptions, buildAst } from './build-ast';
 import { PublishOptions, publish } from './publish';
 import { SynthesizeOptions, synth } from './synth-driver/synth';
 
+
 const log = pino.default({
   prettyPrint: true,
   level: process.env.LOG_LEVEL || 'debug',
@@ -16,7 +17,8 @@ const log = pino.default({
 log.info('started');
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-yargs.default(hideBin(process.argv))
+yargs
+  .default(hideBin(process.argv))
   .command({
     command: 'synth <blueprint>',
     describe: 'locally synthesize the blueprint',
@@ -66,10 +68,16 @@ yargs.default(hideBin(process.argv))
           description: 'the code.aws cookie to use for authorization',
           demandOption: false,
           type: 'string',
+        })
+        .option('endpoint', {
+          description: 'the code.aws endpoint to publish against',
+          demandOption: false,
+          type: 'string',
+          default: 'api-gamma.quokka.codes',
         });
     },
     handler: async (argv: PublishOptions): Promise<void> => {
-      await publish(log, argv.blueprint, argv.publisher, argv.cookie);
+      await publish(log, argv.blueprint, argv.publisher, argv.endpoint, argv.cookie);
       process.exit(0);
     },
   })

--- a/packages/utils/blueprint-cli/src/publish.ts
+++ b/packages/utils/blueprint-cli/src/publish.ts
@@ -8,6 +8,7 @@ export interface PublishOptions extends yargs.Arguments {
   blueprint: string;
   publisher: string;
   cookie?: string;
+  endpoint: string;
 }
 
 interface PublishingJob {
@@ -19,6 +20,7 @@ export async function publish(
   log: pino.BaseLogger,
   blueprint: string,
   publisher: string,
+  endpoint: string,
   cookie?: string,
 ): Promise<void> {
   if (!fs.existsSync(blueprint)) {
@@ -65,8 +67,10 @@ export async function publish(
     process.exit(199);
   }
 
+  log.info('using endpoint: %s', endpoint);
+
   const gqlResponse = await axios.default.post(
-    'https://api-gamma.quokka.codes/graphql?',
+    `https://${endpoint}/graphql?`,
     {
       query: `mutation {
         createBlueprintUploadUrl(input: {
@@ -79,10 +83,9 @@ export async function publish(
     },
     {
       headers: {
-        'authority': 'api-gamma.quokka.codes',
+        'authority': endpoint,
         'accespt': 'application/json',
-        'origin': 'https://api-gamma.quokka.codes',
-        'x-api-key': 'CBxZwFn2o0pofwuIE0yR',
+        'origin': `https://${endpoint}`,
         'cookie': cookie,
         'content-type': 'application/json',
       },


### PR DESCRIPTION
### Issue

Blueprint CLI does not currently support publishing blueprints to multiple environments.  The environment endpoints are hard-coded and there is no way to override the behavior.

### Description

This PR allows a developer to override the endpoint.  I've considered a few options:
* A pre-selected set of environments (gamma | prod)
* Specifying an endpoint manually.

I decided on endpoint manual specification for now to avoid hard-coding details of lower environments.

### Testing

I've published a prod blueprint.

### Additional context

N/A
Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
