### PR TITLE
feat(caws-workflows): add OutputVariables for BuildActionConfiguration

### DIFF
--- a/packages/components/caws-workflows/src/models.ts
+++ b/packages/components/caws-workflows/src/models.ts
@@ -5,6 +5,10 @@ export interface Variables {
   Value: string;
 }
 
+export interface OutputVariables {
+  Name: string;
+}
+
 export interface Step {
   Run: string;
 }
@@ -34,6 +38,7 @@ export interface BuildActionConfiguration {
   Artifacts?: Artifacts[];
   Reports?: Reports[];
   Uses?: ActionUses;
+  OutputVariables?: OutputVariables[];
 }
 
 export interface DeployActionConfiguration {


### PR DESCRIPTION
### Description
* This PR adds `OutputVariables` to the `BuildActionConfiguration` interface. This allows authors to surface build variables in the UI under the `Variables` tab.

### Testing

How was this change tested?

* Manual testing: published a private blueprint with output variables and observed that they showed up in the UI.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
