### PR TITLE
fix(workspaces): add missing 'sleep infinity' entrypoint

### DIFF
--- a/packages/components/caws-workspaces/src/samples/index.ts
+++ b/packages/components/caws-workspaces/src/samples/index.ts
@@ -17,6 +17,7 @@ export class SampleWorkspaces {
         container: {
           image: 'public.ecr.aws/aws-mde/universal-image:latest',
           mountSources: true,
+          command: ['sleep', 'infinity'],
         },
       },
     ],

--- a/packages/components/caws-workspaces/src/workspace-definition.ts
+++ b/packages/components/caws-workspaces/src/workspace-definition.ts
@@ -12,6 +12,7 @@ export interface WorkspaceComponent {
 export interface WorkspaceComponentContainer {
   image: string;
   mountSources: boolean;
+  command: string[];
 }
 
 export interface WorkspaceMetadata {


### PR DESCRIPTION
### Description

What does this implement? Explain your changes.

- Devfile requires an entrypoint that does not exit immediately, using `sleep infinity`

### Testing

How was this change tested?

- Created `packages/blueprints/lambda-python` via `yarn blueprint:synth`
- Result:
```

schemaVersion: 2.0.0
metadata:
  name: aws-universal
  version: 1.0.1
  displayName: AWS Universal
  description: Stack with AWS Universal Tooling
  tags:
    - aws
    - a12
  projectType: aws
components:
  - name: aws-runtime
    container:
      image: public.ecr.aws/aws-mde/universal-image:latest
      mountSources: true
      command:
        - sleep
        - infinity
```
- Used this devfile in an MDE
- Updated the image to see that it still works

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
