### PR TITLE
refactor(web-app): Rename inputs, display API data in the frontend, and show cloudfront url in the build tab

### DIFF
--- a/packages/blueprints/web-app/.projenrc.ts
+++ b/packages/blueprints/web-app/.projenrc.ts
@@ -31,7 +31,7 @@ const blueprint = new ProjenBlueprint({
   ],
   /* Add release management to this project. */
   // release: undefined,
-  keywords: ['blueprint', 'webapp', 'java', 'react'],
+  keywords: ['blueprint', 'webapp', 'typescript', 'react', 'node'],
   homepage: 'https://aws.amazon.com/',
   /* Add media url links to this project */
   mediaUrls: [

--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -59,14 +59,15 @@
   "bundledDependencies": [],
   "keywords": [
     "blueprint",
-    "java",
+    "node",
     "react",
+    "typescript",
     "webapp"
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.32",
+  "version": "0.0.36",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -1,6 +1,8 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import { Environment } from '@caws-blueprint-component/caws-environments';
 import { SourceRepository } from '@caws-blueprint-component/caws-source-repositories';
-import { Workflow, BuildActionConfiguration, Step, WorkflowDefinition } from '@caws-blueprint-component/caws-workflows';
+import { Workflow, BuildActionConfiguration, Step, StageDefinition, WorkflowDefinition } from '@caws-blueprint-component/caws-workflows';
 import { SampleWorkspaces, Workspace } from '@caws-blueprint-component/caws-workspaces';
 import {
   Blueprint as ParentBlueprint,
@@ -23,22 +25,19 @@ import { createClass } from './stack-generator';
  * 5. The 'Options' member values defined in 'defaults.json' will be used to populate the wizard selection panel with default values
 */
 export interface Options extends ParentOptions {
+  repositoryName: string;
   /**
-   * The name of the source repository.
-   */
-  sourceRepositoryName: string;
-  /**
-   * Name of the frontend project and directory.
+   * Name of the folder for the frontend stack, such as react or ui.
    */
   reactFolderName: string;
   /**
-   * Name of the backend project and directory.
+   * Name of the folder for the backend stack, such as node or api.
    */
   nodeFolderName: string;
   /**
    * An array of stage definitions
    */
-  stages: any[];
+  stages: StageDefinition[];
 }
 
 /**
@@ -48,6 +47,7 @@ export interface Options extends ParentOptions {
  */
 export class Blueprint extends ParentBlueprint {
   protected options: Options;
+  protected readonly frontend: web.ReactTypeScriptProject;
 
   constructor(options_: Options) {
     super(options_);
@@ -55,13 +55,13 @@ export class Blueprint extends ParentBlueprint {
     this.options = options;
 
     const repository = new SourceRepository(this, {
-      title: this.options.sourceRepositoryName,
+      title: this.options.repositoryName,
     });
     new Workspace(this, repository, SampleWorkspaces.default);
 
     this.options.stages.forEach(stage => new Environment(this, stage.environment));
 
-    this.createFrontend(repository);
+    this.frontend = this.createFrontend(repository);
     this.createStacks(repository);
     this.createWorkflow(repository);
   }
@@ -74,6 +74,9 @@ export class Blueprint extends ParentBlueprint {
       authorName: 'codeaws',
       outdir: `${repo.relativePath}/${this.options.reactFolderName}`,
       defaultReleaseBranch: 'main',
+      deps: [
+        'axios',
+      ],
     });
 
     // Issue: NPM build crawls up the dependency tree and sees a conflicting version of eslint
@@ -82,7 +85,59 @@ export class Blueprint extends ParentBlueprint {
     const dotenvFile = new SourceCode(project, '.env');
     dotenvFile.line('SKIP_PREFLIGHT_CHECK=true');
 
+    // Need to create a /build directory with an empty .keep file
+    project.gitignore.removePatterns('/build/');
+    createClass(project.outdir, 'build', '.keep', '');
+
     return project;
+  }
+
+  override synth(): void {
+    super.synth();
+
+    // overwite the App.tsx file with some additional logic
+    const sourceCode = [
+      "import logo from './logo.svg';",
+      "import './App.css';",
+      "import axios from 'axios';",
+      "import config from './config.json';",
+      "import { useState, useEffect } from 'react';",
+      '',
+      'function App() {',
+      '  const [result, setResult] = useState({ data: null });',
+      '  useEffect(() => {',
+      '    const getData = async (): Promise<void> => {',
+      '      const result = await axios.get(config.HelloWorldAppApiStack.apiurl);',
+      '      setResult({ data: result.data });',
+      '    };',
+      '    getData();',
+      '  }, []);',
+      '  return (',
+      '   <div className="App">',
+      '      <header className="App-header">',
+      '        <img src={logo} className="App-logo" alt="logo" />',
+      '        <p>',
+      '          Edit <code>src/App.tsx</code> and save to reload.',
+      '        </p>',
+      '        <p>',
+      '          {result.data}',
+      '        </p>',
+      '        <a className="App-link"',
+      '          href="https://reactjs.org"',
+      '          target="_blank"',
+      '          rel="noopener noreferrer"',
+      '        >',
+      '          Learn React',
+      '        </a>',
+      '      </header>',
+      '    </div>',
+      '  );',
+      '}',
+      '',
+      'export default App;',
+      '',
+    ];
+    fs.writeFileSync(path.join(this.frontend.outdir, this.frontend.srcdir, 'App.tsx'), sourceCode.join('\n'));
   }
 
   private createStacks(repo: SourceRepository): Project {
@@ -105,21 +160,15 @@ export class Blueprint extends ParentBlueprint {
       devDeps: [
         'cdk-assets',
       ],
-      context: {
-        // TODO: may be able to remove this
-        //       and is related to using cdk-assets?
-        '@aws-cdk/core:newStyleStackSynthesis': 'true',
-      },
       sampleCode: false,
       lambdaAutoDiscover: true,
       defaultReleaseBranch: 'main',
     });
 
-    const lambdaName = `${this.options.sourceRepositoryName}Lambda`;
+    const lambdaName = `${this.options.repositoryName}Lambda`;
     const lambdaOptions: awscdk.LambdaFunctionOptions = createLambda(project, lambdaName, helloWorldLambdaCallback);
 
-    const stackName = `${this.options.sourceRepositoryName}Stack`;
-
+    const stackName = `${this.options.repositoryName}`;
     const sourceCode = getStackDefinition(stackName, this.options, lambdaOptions);
     createClass(project.outdir, project.srcdir, 'main.ts', sourceCode);
 
@@ -142,7 +191,7 @@ export class Blueprint extends ParentBlueprint {
       Actions: {},
     };
 
-    this.options.stages.forEach((stage: any) => {
+    this.options.stages.forEach((stage: StageDefinition) => {
       this.createDeployAction(stage, workflowDefinition);
     });
 
@@ -151,7 +200,6 @@ export class Blueprint extends ParentBlueprint {
       repository,
       workflowDefinition,
     );
-
   }
 
   private createDeployAction(stage: any, workflow: WorkflowDefinition) {
@@ -162,36 +210,18 @@ export class Blueprint extends ParentBlueprint {
         Steps: [
           { Run: `export awsAccountId=${this.getIdFromArn(stage.role)}` },
           { Run: `export awsRegion=${stage.region}` },
-          { Run: `cd ./${this.options.reactFolderName} && npm install && npm run build` },
-          { Run: `cd ../${this.options.nodeFolderName} && npm install && npm run build` },
-          // { Run: `export AWS_SDK_LOAD_CONFIG=1` },
+          { Run: `cd ./${this.options.nodeFolderName} && npm install && npm run build` },
           { Run: `npm run env -- cdk bootstrap aws://${this.getIdFromArn(stage.role)}/${stage.region}` },
-          { Run: 'npm run env -- cdk deploy --require-approval never' },
-          // TODO - Look into using this to push artifacts to s3.
-          // { Run: `npm run env -- cdk synth` },
-          // { Run: `npm run env -- cdk-assets publish --path ./cdk.out/${this.options.sourceRepositoryName}Stack.assets.json` }
+          { Run: `npm run env -- cdk deploy ${this.options.repositoryName}ApiStack --outputs-file ../${this.options.reactFolderName}/src/config.json --require-approval never` },
+          { Run: `cd ../${this.options.reactFolderName} && npm install && npm run build` },
+          { Run: `cd ../${this.options.nodeFolderName}` },
+          { Run: `npm run env -- cdk deploy ${this.options.repositoryName}Stack --require-approval never --outputs-file config.json` },
+          // TODO - a hack to get the cloudformation url to show up under build outputs
+          { Run: `eval $(jq -r \'.${this.options.repositoryName}Stack | to_entries | .[] | .key + "=" + (.value | @sh) \' \'config.json\')` },
         ] as Step[],
+        OutputVariables: [{ Name: 'CloudFrontURL' }],
       } as BuildActionConfiguration,
     };
-    //         workflow.Actions[`Bootstrap_${stage.environment.title}`] = {
-    //           DependsOn: [`Build_${stage.environment.title}`],
-    //           Identifier: 'aws-actions/cawsbuildprivate-build@v1',
-    //           Configuration: {
-    //             ActionRoleArn: stage.role,
-    //             Steps: [
-    //             ] as Step[],
-    //           }
-    //         }
-
-    //         workflow.Actions[`Deploy_${stage.environment.title}`] = {
-    //           DependsOn: [`Bootstrap_${stage.environment.title}`],
-    //           Identifier: 'aws-actions/cawsbuildprivate-build@v1',
-    //           Configuration: {
-    //             ActionRoleArn: stage.role,
-    //             Steps: [
-    //             ] as Step[],
-    //           } as BuildActionConfiguration,
-    //         };
   };
 
   private getIdFromArn(arnRole: string) {

--- a/packages/blueprints/web-app/src/defaults.json
+++ b/packages/blueprints/web-app/src/defaults.json
@@ -1,15 +1,15 @@
 {
-  "sourceRepositoryName": "HelloWorldWebApp",
-  "reactFolderName": "client",
-  "nodeFolderName": "api",
+  "repositoryName": "HelloWorldApp",
+  "reactFolderName": "react",
+  "nodeFolderName": "node",
   "stages": [
     {
       "environment": {
-        "title": "prod",
-        "description": "this is my prod stage"
+        "title": "personal",
+        "description": "this is my personal test environment"
       },
       "role": "REPLACE_ME_DEPLOY_ROLE_ARN",
-      "region": "us-west-1"
+      "region": "us-west-2"
     }
   ]
 }

--- a/packages/blueprints/web-app/src/hello-world-lambda.ts
+++ b/packages/blueprints/web-app/src/hello-world-lambda.ts
@@ -1,6 +1,10 @@
 export function helloWorldLambdaCallback(): any {
   return {
     statusCode: 200,
-    body: 'hello world',
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+    },
+    body: 'hello world from a lambda backend',
   };
 };


### PR DESCRIPTION
### Description
This PR relates to polishing the web-app blueprint and accomplishes several goals:
1. Renames and removes the inputs in the wizard
2. Connects the frontend and backend stacks so response from the Lambda API is displayed on the app.
3. Displays the CloudfrontUrl in the `Output Variables` window of the `Outputs` tab.

### Testing

* Manual testing: Published blueprint and created a successful project that deployed a full stack webapp.
