### PR TITLE
feat(workflows) Add environment context and actions per environment

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -25,6 +25,7 @@ export class Blueprint extends Project {
       rootDir: path.resolve(this.outdir),
       organizationName: process.env.CONTEXT_ORGANIZATIONNAME,
       projectName: process.env.CONTEXT_PROJECTNAME,
+      environmentId: process.env.CONTEXT_ENVIRONMENTID,
       npmConfiguration: {
         token: process.env.NPM_CONFIG_TOKEN,
         registry:

--- a/packages/blueprints/blueprint/src/context.ts
+++ b/packages/blueprints/blueprint/src/context.ts
@@ -6,6 +6,7 @@ export interface NpmConfiguration {
 export interface Context {
   readonly organizationName?: string;
   readonly projectName?: string;
+  readonly environmentId?: string;
   readonly rootDir: string;
   readonly npmConfiguration: NpmConfiguration;
 }

--- a/packages/blueprints/lambda-python/src/blueprint.ts
+++ b/packages/blueprints/lambda-python/src/blueprint.ts
@@ -87,6 +87,7 @@ export class Blueprint extends ParentBlueprint {
       this,
       this.repository,
       generateWorkflow(
+        this,
         'sam-python',
         'main',
         options.stages,
@@ -120,8 +121,11 @@ export class Blueprint extends ParentBlueprint {
   }
 
   protected addSamInstallScript() {
-    new SampleFile(this, path.join(this.repository.relativePath, '.aws', 'scripts', 'setup-sam.sh'), {
-      contents: `#!/usr/bin/env bash
+    new SampleFile(
+      this,
+      path.join(this.repository.relativePath, '.aws', 'scripts', 'setup-sam.sh'),
+      {
+        contents: `#!/usr/bin/env bash
 echo "Setting up sam"
 
 yum install unzip -y
@@ -131,7 +135,8 @@ unzip -qq aws-sam-cli-linux-x86_64.zip -d sam-installation-directory
 
 ./sam-installation-directory/install; export AWS_DEFAULT_REGION=us-west-2
 `,
-    });
+      },
+    );
   }
 
   protected createSamTemplate(desination: string, options: Options): void {

--- a/packages/components/caws-workflows/src/actions.ts
+++ b/packages/components/caws-workflows/src/actions.ts
@@ -1,0 +1,27 @@
+export enum ActionIdentifierAlias {
+  build = 'build',
+  deploy = 'deploy',
+  test = 'test',
+}
+
+const ACTION_IDENTIFIERS: {[key: string]: {default: string; prod: string}} = {
+  build: {
+    default: 'aws-actions/cawsbuildprivate-build@v1',
+    prod: 'aws/build@v1',
+  },
+  test: {
+    default: 'aws-actions/cawstestbeta-test@v1',
+    prod: 'aws/managed-test@v1',
+  },
+  deploy: {
+    default: 'aws/cloudformation-deploy-gamma@v1',
+    prod: 'aws/cloudformation-deploy@v1',
+  },
+};
+
+export function getDefaultActionIdentifier(
+  alias: ActionIdentifierAlias,
+  environmentIdentifier: string = 'default',
+): string | undefined {
+  return ACTION_IDENTIFIERS[alias]?.[environmentIdentifier] ?? ACTION_IDENTIFIERS[alias]?.default;
+}

--- a/packages/components/caws-workflows/src/index.ts
+++ b/packages/components/caws-workflows/src/index.ts
@@ -6,6 +6,7 @@ import { Component, YamlFile } from 'projen';
 
 import { WorkflowDefinition } from './models';
 
+export * from './actions';
 export * from './models';
 export * from './samples/node';
 export * from './factories/index';

--- a/packages/components/caws-workflows/src/models.ts
+++ b/packages/components/caws-workflows/src/models.ts
@@ -107,5 +107,5 @@ export enum PullRequestEvent {
   OPEN = 'open',
   CLOSED = 'closed',
   MERGED = 'merged',
-  REVISION = 'revision'
+  REVISION = 'revision',
 }


### PR DESCRIPTION
### Description

This PR adds an environment identifier to blueprint context.  We then add environment specific actions and a convenient way to look up the correct action identifier.

### Testing

Local synthesis of blueprints to confirm the behavior.

### Additional context

This workaround should be somewhat temporary.  Workflows are looking to standardize action identifiers between environments, but not for several months.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
