### PR TITLE
feat(caws-workflows): update DeployActionConfiguration to be compatib…

### DIFF
--- a/packages/components/caws-workflows/src/actions.ts
+++ b/packages/components/caws-workflows/src/actions.ts
@@ -14,8 +14,8 @@ const ACTION_IDENTIFIERS: {[key: string]: {default: string; prod: string}} = {
     prod: 'aws/managed-test@v1',
   },
   deploy: {
-    default: 'aws/cloudformation-deploy-gamma@v1',
-    prod: 'aws/cloudformation-deploy@v1',
+    default: 'aws/cfn-deploy-gamma@v1',
+    prod: 'aws/cfn-deploy@v1',
   },
 };
 

--- a/packages/components/caws-workflows/src/factories/index.ts
+++ b/packages/components/caws-workflows/src/factories/index.ts
@@ -128,15 +128,14 @@ export function addGenericCloudFormationDeployAction(
     ),
     InputArtifacts: [artifactName],
     Configuration: {
-      CodeAwsRoleARN: stage.role,
-      StackRoleARN: stage.stackRoleArn,
-      StackName: stackName,
-      StackRegion: stackRegion,
-      TemplatePath: `${artifactName}::output.yaml`,
-      EnvironmentName: stage.environment.title,
-      Parameters: [],
-      RollbackConfiguration: {
-        MonitorAlarmARNs: [],
+      ActionRoleArn: stage.role,
+      DeploymentEnvironment: stage.environment.title,
+      Parameters: {
+        'name': stackName,
+        'region': stackRegion,
+        'role-arn': stage.stackRoleArn,
+        'template': './output.yaml',
+        'capabilities': 'CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM',
       },
     },
   };

--- a/packages/components/caws-workflows/src/models.ts
+++ b/packages/components/caws-workflows/src/models.ts
@@ -42,15 +42,14 @@ export interface BuildActionConfiguration {
 }
 
 export interface DeployActionConfiguration {
-  CodeAwsRoleARN: string;
-  StackRoleARN: string;
-  StackName: string;
-  StackRegion: string;
-  TemplatePath: string;
-  EnvironmentName: string;
-  Parameters: [];
-  RollbackConfiguration: {
-    MonitorAlarmARNs: [];
+  ActionRoleArn: string;
+  DeploymentEnvironment: string;
+  Parameters: {
+    name: string;
+    region: string;
+    'role-arn': string;
+    template: string;
+    capabilities: string;
   };
 }
 


### PR DESCRIPTION
…le with AEF-based actions

### Issue

#DEPLOY-12608

### Description

Modifies the workflow YAML for the SAM serverless blueprint for the new AEF-based CloudFormation deploy action, off of the now "legacy" CloudFormation deploy action.

### Testing

Applied code changes, `yarn build`, then executed a `synth` on the SAM serverless blueprint. Verified that outputted YAML for the workflow action matches the migration document here: https://quip-amazon.com/rxfTARmhLoIL/CFN-Action-Updates-Impact-to-Project-Blueprints

### Additional context

Workflow YAML produced by `synth`:

```

Name: build-and-release
Triggers:
  - Type: Push
    Branches:
      - main
Actions:
  Build:
    Identifier: aws-actions/cawsbuildprivate-build@v1
    OutputArtifacts:
      - MyServerlessAppArtifact
    Configuration:
      Variables:
        - Name: BUILD_ROLE_ARN
          Value: REPLACE_ME
      Steps:
        - Run: . ./.aws/scripts/setup-sam.sh
        - Run: sam build
        - Run: sam package --template-file ./.aws-sam/build/template.yaml --s3-bucket
            REPLACE_ME --output-template-file output.yaml --region us-west-2
      Artifacts:
        - Name: MyServerlessAppArtifact
          Files:
            - output.yaml
  Deploy_prod-v4t3y:
    DependsOn:
      - Build
    Identifier: aws/cfn-deploy-gamma@v1
    InputArtifacts:
      - MyServerlessAppArtifact
    Configuration:
      ActionRoleArn: REPLACE_ME
      DeploymentEnvironment: prod-v4t3y
      Parameters:
        name: REPLACE_ME-prod-v4t3y
        region: us-west-2
        role-arn: REPLACE_ME
        template: ./output.yaml
        capabilities: CAPABILITY_AUTO_EXPAND,CAPABILITY_IAM
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
