### PR TITLE
feat(workspaces): adding volume mount on /var/lib/docker directory in default devfile

### DIFF
--- a/packages/components/caws-workspaces/src/samples/index.ts
+++ b/packages/components/caws-workspaces/src/samples/index.ts
@@ -18,6 +18,18 @@ export class SampleWorkspaces {
           image: 'public.ecr.aws/aws-mde/universal-image:latest',
           mountSources: true,
           command: ['sleep', 'infinity'],
+          volumeMounts: [
+            {
+              name: 'docker-store',
+              path: '/var/lib/docker',
+            },
+          ],
+        },
+      },
+      {
+        name: 'docker-store',
+        volume: {
+          size: '16Gi',
         },
       },
     ],

--- a/packages/components/caws-workspaces/src/workspace-definition.ts
+++ b/packages/components/caws-workspaces/src/workspace-definition.ts
@@ -6,13 +6,24 @@ export interface WorkspaceDefinition {
 
 export interface WorkspaceComponent {
   name: string;
-  container: WorkspaceComponentContainer;
+  container?: WorkspaceComponentContainer;
+  volume?: WorkspaceComponentVolume;
 }
 
 export interface WorkspaceComponentContainer {
   image: string;
   mountSources: boolean;
   command: string[];
+  volumeMounts: VolumeMount[];
+}
+
+export interface VolumeMount {
+  name: string;
+  path: string;
+}
+
+export interface WorkspaceComponentVolume {
+  size: string;
 }
 
 export interface WorkspaceMetadata {


### PR DESCRIPTION
### Description

What does this implement? Explain your changes.

*  mounted a persistent volume on ```/var/lib/docker``` directory in the universal image to allow docker running within it to use overlay2 filesystem for better performance

### Testing

How was this change tested?

* Built ```packages/blueprints/web-app``` via ```yarn blueprint:synth```
* Result:

```

schemaVersion: 2.0.0
metadata:
  name: aws-universal
  version: 1.0.1
  displayName: AWS Universal
  description: Stack with AWS Universal Tooling
  tags:
    - aws
    - a12
  projectType: aws
components:
  - name: aws-runtime
    container:
      image: public.ecr.aws/aws-mde/universal-image:latest
      mountSources: true
      command:
        - sleep
        - infinity
      volumeMounts:
        - name: docker-store
          path: /var/lib/docker
  - name: docker-store
    volume:
      size: 16Gi
```
* Used the generated devfile in an MDE


### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
