### PR TITLE
feat(components): updated publishing use a csrf token

### DIFF
--- a/packages/blueprints/import-from-git/package.json
+++ b/packages/blueprints/import-from-git/package.json
@@ -59,7 +59,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.21",
+  "version": "0.0.24",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/utils/blueprint-cli/src/publish.ts
+++ b/packages/utils/blueprint-cli/src/publish.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as axios from 'axios';
 import * as pino from 'pino';
 import * as yargs from 'yargs';
+import { verifyIdentity } from './verify-identity';
 
 export interface PublishOptions extends yargs.Arguments {
   blueprint: string;
@@ -67,6 +68,9 @@ export async function publish(
     process.exit(199);
   }
 
+  log.info('verifying identity');
+  const indentity = await verifyIdentity({ endpoint, cookie });
+  log.info(`Publishing as ${indentity.name} at ${indentity.email}`);
   log.info('using endpoint: %s', endpoint);
 
   const gqlResponse = await axios.default.post(
@@ -87,6 +91,7 @@ export async function publish(
         'accespt': 'application/json',
         'origin': `https://${endpoint}`,
         'cookie': cookie,
+        'anti-csrftoken-a2z': indentity.csrfToken,
         'content-type': 'application/json',
       },
     },

--- a/packages/utils/blueprint-cli/src/verify-identity.ts
+++ b/packages/utils/blueprint-cli/src/verify-identity.ts
@@ -1,0 +1,42 @@
+import * as axios from 'axios';
+
+interface IdentityResponse {
+  name: string;
+  email: string;
+  csrfToken: string;
+}
+export const verifyIdentity = async (options: {
+  endpoint: string;
+  cookie: string;
+}): Promise<IdentityResponse> => {
+  const { endpoint, cookie } = options;
+  const gqlResponse = await axios.default.post(
+    `https://${endpoint}/graphql?`,
+    {
+      query: `query verifySession {
+        verifySession {
+          self {
+            displayName,
+            primaryEmail {
+              email,
+            },
+          }
+        }
+      }`,
+    },
+    {
+      headers: {
+        'authority': endpoint,
+        'accespt': 'application/json',
+        'origin': `https://${endpoint}`,
+        'cookie': cookie,
+        'content-type': 'application/json',
+      },
+    },
+  );
+  return {
+    email: gqlResponse.data.data.verifySession.self.primaryEmail.email,
+    name: gqlResponse.data.data.verifySession.self.displayName,
+    csrfToken: gqlResponse.headers['anti-csrftoken-a2z'],
+  };
+};


### PR DESCRIPTION
### Issue

FUSI apis require a csrf token.

### Description

The CLI makes a request to verify identity and then passes the CSRF token along to publish URL

### Testing

Republished GIthub. Serg's team verified that this worked properly on their side.
