### PR TITLE
fix(web-app): Incorrect cdkMajorVersion and svg loader bug causing build issues

### DIFF
--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -65,7 +65,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.59",
+  "version": "0.0.63",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -107,6 +107,13 @@ export class Blueprint extends ParentBlueprint {
       outdir: `${this.repository.relativePath}/${this.options.reactFolderName}`,
       defaultReleaseBranch: 'main',
       deps: ['axios'],
+      tsconfig: {
+        // Related to https://github.com/projen/projen/issues/1462
+        include: ['src', 'src/loader.d.ts'],
+        compilerOptions: {
+          noUnusedLocals: false,
+        },
+      },
     });
 
     // Issue: NPM build crawls up the dependency tree and sees a conflicting version of eslint
@@ -203,6 +210,18 @@ export class Blueprint extends ParentBlueprint {
     fs.writeFileSync(
       path.join(this.frontend.outdir, this.frontend.srcdir, 'App.tsx'),
       sourceCode.join('\n'),
+    );
+
+    // Related to https://github.com/projen/projen/issues/1462
+    const loaderCode = [
+      "declare module '*.svg' {",
+      'const content: any;',
+      'export default content;',
+      '}',
+    ];
+    fs.writeFileSync(
+      path.join(this.frontend.outdir, this.frontend.srcdir, 'loader.d.ts'),
+      loaderCode.join('\n'),
     );
   }
 

--- a/packages/blueprints/web-app/src/lambda-generator.ts
+++ b/packages/blueprints/web-app/src/lambda-generator.ts
@@ -1,4 +1,4 @@
-import { SourceCode, typescript, awscdk } from 'projen';
+import { SourceCode, typescript, awscdk, DependencyType } from 'projen';
 
 /**
  * @param project
@@ -8,12 +8,10 @@ import { SourceCode, typescript, awscdk } from 'projen';
  * @returns
  */
 export function createLambda(project: typescript.TypeScriptAppProject, functionName: string, callback: Function): awscdk.LambdaFunctionOptions {
-
-  //TODO: we should make this into a better object
-  const cdkDeps: awscdk.AwsCdkDeps = {
+  const cdkDeps: awscdk.AwsCdkDeps = new awscdk.AwsCdkDepsJs(project, {
+    dependencyType: DependencyType.BUILD,
     cdkVersion: '1.95.0',
-    cdkMinimumVersion: '1.95.0',
-  } as awscdk.AwsCdkDeps;
+  });
 
   const options: awscdk.LambdaFunctionOptions = {
     entrypoint: `${project.srcdir}/${functionName}.lambda.ts`,


### PR DESCRIPTION
### Issue
* https://issues.amazon.com/CODE-8160

### Description
* The projen bump caused backwards-incompatible issues in regards to lambda and react versions.

### Testing

How was this change tested?

* npm run build-server
* npm run build-client
