### PR TITLE
feat(web-app): Add report auto-discovery to workflow

### DIFF
--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -10,6 +10,8 @@ import {
   Workflow,
   WorkflowDefinition,
   getDefaultActionIdentifier,
+  Artifacts,
+  Reports,
 } from '@caws-blueprint-component/caws-workflows';
 import { SampleWorkspaces, Workspace } from '@caws-blueprint-component/caws-workspaces';
 import {
@@ -289,6 +291,8 @@ export class Blueprint extends ParentBlueprint {
   }
 
   private createDeployAction(stage: any, workflow: WorkflowDefinition) {
+    const AUTO_DISCOVERY_ARTIFACT_NAME =  'AutoDiscoveryArtifact';
+
     workflow.Actions[`Build_${stage.environment.title}`] = {
       Identifier: getDefaultActionIdentifier(
         ActionIdentifierAlias.build,
@@ -318,8 +322,15 @@ export class Blueprint extends ParentBlueprint {
             Run: `eval $(jq -r \'.${this.options.repositoryName}Stack | to_entries | .[] | .key + "=" + (.value | @sh) \' \'config.json\')`,
           },
         ] as Step[],
+        Artifacts: [
+          { Name: AUTO_DISCOVERY_ARTIFACT_NAME, Files: ['**/*'] },
+        ] as Artifacts[],
+        Reports: [
+          { Name: 'AutoDiscovered', AutoDiscover: true, TestResults: [{ ReferenceArtifact: AUTO_DISCOVERY_ARTIFACT_NAME }] },
+        ] as Reports[],
         OutputVariables: [{ Name: 'CloudFrontURL' }],
       } as BuildActionConfiguration,
+      OutputArtifacts: [AUTO_DISCOVERY_ARTIFACT_NAME],
     };
   }
 

--- a/packages/components/caws-workflows/src/models.ts
+++ b/packages/components/caws-workflows/src/models.ts
@@ -28,6 +28,7 @@ export interface TestResult {
 
 export interface Reports {
   Name: string;
+  AutoDiscover?: boolean;
   TestResults: TestResult[];
 }
 


### PR DESCRIPTION
### Issue

N/A

### Description

Adds report auto-discovery to web-app workflow.

### Testing

`yarn blueprint:synth` in the web-app blueprint. Generated workflow YAML is correct ✅:

```yaml
Name: buildAssets
Triggers:
  - Type: push
    Branches:
      - main
Actions:
  Build_development:
    Identifier: aws-actions/cawsbuildprivate-build@v1
    Configuration:
      ActionRoleArn: REPLACE_ME_DEPLOY_ROLE_ARN
      Steps:
        - Run: export awsAccountId=undefined
        - Run: export awsRegion=us-west-2
        - Run: cd ./node && npm install && npm run build
        - Run: npm run env -- cdk bootstrap aws://undefined/us-west-2
        - Run: npm run env -- cdk deploy HelloWorldAppApiStack --outputs-file ../react/src/config.json --require-approval never
        - Run: cd ../react && npm install && npm run build
        - Run: cd ../node
        - Run: npm run env -- cdk deploy HelloWorldAppStack --require-approval never --outputs-file config.json
        - Run: eval $(jq -r '.HelloWorldAppStack | to_entries | .[] | .key + "=" + (.value | @sh) ' 'config.json')
      Artifacts:
        - Name: AutoDiscoveryArtifact
          Files:
            - "**/*"
      Reports:
        - Name: AutoDiscovered
          AutoDiscover: true
          TestResults:
            - ReferenceArtifact: AutoDiscoveryArtifact
      OutputVariables:
        - Name: CloudFrontURL
    OutputArtifacts:
      - AutoDiscoveryArtifact
```

Tested in a real CAWS project with pared-down yaml:

```yaml
Name: buildAssets
Triggers:
  - Type: push
    Branches:
      - main
Actions:
  Build_development:
    Identifier: aws-actions/cawsbuildprivate-build@v1
    Configuration:
      Steps:
        - Run: cd ./node && npm install && npm run build
        - Run: cd ../react && npm install && npm run build
      Artifacts:
        - Name: AutoDiscoveryArtifact
          Files:
            - "**/*"
      Reports:
        - Name: AutoDiscovered
          AutoDiscover: true
          TestResults:
            - ReferenceArtifact: AutoDiscoveryArtifact
      OutputVariables:
        - Name: CloudFrontURL
    OutputArtifacts:
      - AutoDiscoveryArtifact
```

Confirmed that reports were correctly auto-discovered ✅

### Additional context

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
