### PR TITLE
feat(web-app): Generate test and coverage reports for client

### DIFF
--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -109,6 +109,7 @@ export class Blueprint extends ParentBlueprint {
       outdir: `${this.repository.relativePath}/${this.options.reactFolderName}`,
       defaultReleaseBranch: 'main',
       deps: ['axios'],
+      devDeps: ['jest-junit'],
       tsconfig: {
         // Related to https://github.com/projen/projen/issues/1462
         include: ['src', 'src/loader.d.ts'],
@@ -117,6 +118,11 @@ export class Blueprint extends ParentBlueprint {
         },
       },
     });
+
+    // Override the react-scripts test command to generate coverage and test reports
+    project.testTask.reset();
+    project.testTask.exec('react-scripts test --watchAll=false --coverage --reporters default --reporters jest-junit');
+    project.gitignore.addPatterns('junit.xml');
 
     // Issue: NPM build crawls up the dependency tree and sees a conflicting version of eslint
     //  that is incompatible with create-react-app (i.e react-scripts). We skip the preflight check
@@ -291,7 +297,7 @@ export class Blueprint extends ParentBlueprint {
   }
 
   private createDeployAction(stage: any, workflow: WorkflowDefinition) {
-    const AUTO_DISCOVERY_ARTIFACT_NAME =  'AutoDiscoveryArtifact';
+    const AUTO_DISCOVERY_ARTIFACT_NAME = 'AutoDiscoveryArtifact';
 
     workflow.Actions[`Build_${stage.environment.title}`] = {
       Identifier: getDefaultActionIdentifier(


### PR DESCRIPTION
### Issue

N/A

### Description

Adds test reports and code coverage reports for the react client app by default, similar to what's being generated for the server. The client runs tests using react-scripts (i.e. create-react-app), and specifying the command line args like this is the only way to tell react scripts to generate [coverage](https://create-react-app.dev/docs/running-tests/#coverage-reporting) and [test reports](https://github.com/facebook/create-react-app/issues/2474).

### Testing

* `yarn blueprint:synth` for web-app ✅ 
* Confirmed that client project builds ✅ 
* Confirmed that coverage and test reports are generated ✅ 

### Additional context

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
