### PR TITLE
feat(workspaces): Update workspace template

### DIFF
--- a/packages/components/caws-workspaces/src/samples/index.ts
+++ b/packages/components/caws-workspaces/src/samples/index.ts
@@ -17,7 +17,7 @@ export class SampleWorkspaces {
         container: {
           image: 'public.ecr.aws/aws-mde/universal-image:latest',
           mountSources: true,
-          command: ['sleep', 'infinity'],
+          args: ['sleep', 'infinity'],
           volumeMounts: [
             {
               name: 'docker-store',

--- a/packages/components/caws-workspaces/src/workspace-definition.ts
+++ b/packages/components/caws-workspaces/src/workspace-definition.ts
@@ -13,7 +13,8 @@ export interface WorkspaceComponent {
 export interface WorkspaceComponentContainer {
   image: string;
   mountSources: boolean;
-  command: string[];
+  command?: string[];
+  args?: string[];
   volumeMounts: VolumeMount[];
 }
 


### PR DESCRIPTION
### Description

This PR updates the workspace template to use the `args` parameter instead of the `command` parameter. This ensures that the `entrypoint` of the Docker image is not overridden.

### Testing

Tested by synthesizing the blueprints and starting an environment using the generated Devfile.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.
