### PR TITLE
fix(blueprints): string[] is unsupported

### DIFF
--- a/packages/blueprints/blueprint-builder/package.json
+++ b/packages/blueprints/blueprint-builder/package.json
@@ -63,7 +63,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.66",
+  "version": "0.0.69",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/blueprint-builder/src/blueprint.ts
+++ b/packages/blueprints/blueprint-builder/src/blueprint.ts
@@ -40,11 +40,6 @@ export interface Options extends ParentOptions {
   authorName: string;
 
   /**
-   * Tags for your Blueprint:
-   */
-  tags?: string[];
-
-  /**
    * @collapsed true
    */
   advancedSettings?: {
@@ -145,7 +140,7 @@ export class Blueprint extends ParentBlueprint {
       description: `${this.options.description}`,
 
       devDeps: ['ts-node', 'typescript', '@caws-blueprint-util/projen-blueprint', '@caws-blueprint-util/blueprint-cli'],
-      keywords: this.options.tags || ['no-tag'],
+      keywords: ['<<tags>>'],
       homepage: '',
       mediaUrls: [
         'https://w7.pngwing.com/pngs/147/242/png-transparent-amazon-com-logo-amazon-web-services-amazon-elastic-compute-cloud-amazon-virtual-private-cloud-cloud-computing-text-orange-logo.png',

--- a/packages/blueprints/frontend-showcase/package.json
+++ b/packages/blueprints/frontend-showcase/package.json
@@ -61,7 +61,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://w7.pngwing.com/pngs/147/242/png-transparent-amazon-com-logo-amazon-web-services-amazon-elastic-compute-cloud-amazon-virtual-private-cloud-cloud-computing-text-orange-logo.png"

--- a/packages/blueprints/frontend-showcase/src/blueprint.ts
+++ b/packages/blueprints/frontend-showcase/src/blueprint.ts
@@ -97,6 +97,11 @@ export interface Options extends ParentOptions {
      */
     stringInput: string;
   };
+
+  /**
+   * String list input
+   */
+  stringListInput?: string[];
 }
 
 /**


### PR DESCRIPTION
### Issue

The wizard does not support `string[]` gracefully. 

### Description
Removing `string[]` annotation from blueprint-builder to unblock builders. Adding it to frontend-showcase for implementation support and regression catching. 
