### PR TITLE
fix (sam/web-app): regexp negative lookbehind not supported by safari

### DIFF
--- a/packages/blueprints/sam-serverless-app/package.json
+++ b/packages/blueprints/sam-serverless-app/package.json
@@ -60,7 +60,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.154",
+  "version": "0.0.156",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://media.amazonwebservices.com/blog/2018/sam_squirrel_1.jpg"

--- a/packages/blueprints/sam-serverless-app/src/blueprint.ts
+++ b/packages/blueprints/sam-serverless-app/src/blueprint.ts
@@ -74,7 +74,7 @@ export interface Options extends ParentOptions {
   code: {
     /**
      * @displayName Code Repository name
-     * @validationRegex /^[a-zA-Z0-9_.-]{1,100}$(?<!.git$)/
+     * @validationRegex /(?!.*\.git$)^[a-zA-Z0-9_.-]{1,100}$/
      * @validationMessage Must contain only alphanumeric characters, periods (.), underscores (_), dashes (-) and be up to 100 characters in length. Cannot end in .git or contain spaces
      */
     sourceRepositoryName: string;

--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -67,7 +67,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.170",
+  "version": "0.0.173",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -52,7 +52,7 @@ export interface Options extends ParentOptions {
   webappOptions: {
     /**
      * @displayName Code Repository Name
-     * @validationRegex /^[a-zA-Z0-9_.-]{1,100}$(?<!.git$)/
+     * @validationRegex /(?!.*\.git$)^[a-zA-Z0-9_.-]{1,100}$/
      * @validationMessage Must contain only alphanumeric characters, periods (.), underscores (_), dashes (-) and be up to 100 characters in length. Cannot end in .git or contain spaces
      */
     repositoryName: string;


### PR DESCRIPTION
### Description

Safari does not support negative lookbehinds for regexp, updating them to use negative lookaheads instead
https://caniuse.com/?search=js-regexp-negative

### Testing

checking blueprint previews load/synth on different browsers 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
