### PR TITLE
fix(blueprint-builder): ts-node has a bug with underlying deps

### DIFF
--- a/packages/blueprints/blueprint-builder/src/blueprint.ts
+++ b/packages/blueprints/blueprint-builder/src/blueprint.ts
@@ -200,6 +200,7 @@ export class Blueprint extends ParentBlueprint {
         "import { ProjenBlueprint } from '@caws-blueprint-util/projen-blueprint';",
         '',
         `const project = new ProjenBlueprint(${JSON.stringify(this.newBlueprintOptions, null, 2)});`,
+        "project.package.addDevDeps('ts-node@^10');",
         '',
         'project.synth();',
       ].join('\n'),


### PR DESCRIPTION
### Issue

required fix for 

https://stackoverflow.com/questions/72488958/false-expression-non-string-value-passed-to-ts-resolvetypereferencedirective

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
