### PR TITLE
Limit the length of the S3 bucket name

### DIFF
--- a/packages/blueprints/web-app/.projen/deps.json
+++ b/packages/blueprints/web-app/.projen/deps.json
@@ -14,6 +14,10 @@
       "type": "build"
     },
     {
+      "name": "@types/uuid",
+      "type": "build"
+    },
+    {
       "name": "@typescript-eslint/eslint-plugin",
       "version": "^5",
       "type": "build"
@@ -65,6 +69,10 @@
     },
     {
       "name": "typescript",
+      "type": "build"
+    },
+    {
+      "name": "uuid",
       "type": "build"
     },
     {

--- a/packages/blueprints/web-app/.projen/tasks.json
+++ b/packages/blueprints/web-app/.projen/tasks.json
@@ -185,7 +185,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @caws-blueprint-util/blueprint-cli @caws-blueprint-util/projen-blueprint @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint json-schema npm-check-updates standard-version ts-node typescript @caws-blueprint-component/caws-environments @caws-blueprint-component/caws-source-repositories @caws-blueprint-component/caws-workflows @caws-blueprint-component/caws-workspaces @caws-blueprint-util/blueprint-utils @caws-blueprint/blueprints.blueprint"
+          "exec": "yarn upgrade @caws-blueprint-util/blueprint-cli @caws-blueprint-util/projen-blueprint @types/node @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint json-schema npm-check-updates standard-version ts-node typescript uuid @caws-blueprint-component/caws-environments @caws-blueprint-component/caws-source-repositories @caws-blueprint-component/caws-workflows @caws-blueprint-component/caws-workspaces @caws-blueprint-util/blueprint-utils @caws-blueprint/blueprints.blueprint"
         },
         {
           "exec": "npx projen"

--- a/packages/blueprints/web-app/.projenrc.ts
+++ b/packages/blueprints/web-app/.projenrc.ts
@@ -24,7 +24,7 @@ const blueprint = new ProjenBlueprint({
   packageName: '@caws-blueprint/blueprints.web-app',
   publishingOrganization: 'blueprints',
   /* Build dependencies for this module. */
-  devDeps: ['ts-node', '@caws-blueprint-util/blueprint-cli', '@caws-blueprint-util/projen-blueprint'],
+  devDeps: ['ts-node', '@caws-blueprint-util/blueprint-cli', '@caws-blueprint-util/projen-blueprint', 'uuid', '@types/uuid'],
   /* Add release management to this project. */
   // release: undefined,
   keywords: ['blueprint', 'webapp', 'typescript', 'react', 'node'],

--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -35,6 +35,7 @@
     "@caws-blueprint-util/blueprint-cli": "0.0.x",
     "@caws-blueprint-util/projen-blueprint": "0.0.x",
     "@types/node": "^12",
+    "@types/uuid": "*",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
@@ -46,7 +47,8 @@
     "projen": "*",
     "standard-version": "^9",
     "ts-node": "^9",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "uuid": "*"
   },
   "dependencies": {
     "@caws-blueprint-component/caws-environments": "0.0.x",
@@ -67,7 +69,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.191",
+  "version": "0.0.192-preview.2",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/src/backend/create-stack.ts
+++ b/packages/blueprints/web-app/src/backend/create-stack.ts
@@ -1,5 +1,6 @@
 import { basename } from 'path';
 import { awscdk } from 'projen';
+import { v4 as uuidv4 } from 'uuid'; // eslint-disable-line import/no-extraneous-dependencies
 const TYPESCRIPT_EXT = '.ts';
 
 export function getStackDefinition(params: {
@@ -134,12 +135,8 @@ app.synth();
   );
 }
 
-function getUniqueS3BucketName(repositoryName: string) {
-  return `${repositoryName.toLowerCase()}-${getSecondSinceEpoch()}`;
-}
-
-function getSecondSinceEpoch() {
-  return Math.floor(Date.now() / 1000);
+function getUniqueS3BucketName(bucketName: string) {
+  return `${bucketName.toLowerCase()}-${uuidv4().toString().slice(0, 16)}`;
 }
 
 export function getStackTestDefintion(appEntrypoint: string, backendStackName: string, frontendStackName: string) {

--- a/packages/blueprints/web-app/src/blueprint.ts
+++ b/packages/blueprints/web-app/src/blueprint.ts
@@ -132,9 +132,9 @@ export class Blueprint extends ParentBlueprint {
     this.nodeFolderName = makeValidFolder(nodeFolderName);
 
     const stackNameBase = options.advanced.stackName.charAt(0).toUpperCase() + options.advanced.stackName.slice(1);
-    this.frontendStackName = this.applySuffix(stackNameBase, 'FrontendStack', 128);
-    this.backendStackName = this.applySuffix(stackNameBase, 'BackendStack', 128);
-    const s3BucketName = options.advanced.stackName.toLowerCase();
+    this.frontendStackName = this.applySuffix(stackNameBase, 128, 'FrontendStack');
+    this.backendStackName = this.applySuffix(stackNameBase, 128, 'BackendStack');
+    const s3BucketName = this.applySuffix(options.advanced.stackName.toLowerCase(), 30);
 
     let lambdaNames: string[] = [options.advanced.lambdaName || 'defaultLambdaHandler'];
     lambdaNames = lambdaNames.map(lambdaName => `${lambdaName[0].toUpperCase()}${lambdaName.slice(1)}`);
@@ -292,11 +292,12 @@ export class Blueprint extends ParentBlueprint {
     });
   }
 
-  applySuffix(str: string, suffix: string, maxLength: number): string {
-    const stringLength = str.length + suffix.length;
+  applySuffix(str: string, maxLength: number, suffix?: string): string {
+    const _suffix = suffix ?? '';
+    const stringLength = str.length + _suffix.length;
     if (stringLength <= maxLength) {
-      return str + suffix;
+      return str + _suffix;
     }
-    return str.slice(0, -(stringLength - maxLength)) + suffix;
+    return str.slice(0, -(stringLength - maxLength)) + _suffix;
   }
 }


### PR DESCRIPTION
### Issue

[SIM](https://sim.amazon.com/issues/BLUEPRINTS-3277)

### Description

Fixes the above issue by limiting the length of the s3 bucket. I've also replaced the randomizer with a truncated uuid. That provides sufficient randomness, no collisions in sq root(2^64).

I've limited it to 30 because the length limit for S3 is 63 chars and I need to leave out 14 chars for the region (longest possible is 14 chars) which is appended later and 16 chars for the uuid (3 more for potential longer region names in the future).
### Testing


Synth and previewed. The workflow succeeded even when I used a long CFn stack name.
### Additional context

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
