### PR TITLE
fix(web-app): limit the length of the S3 bucket for web-app blueprint to under 63 chars

### DIFF
--- a/packages/blueprints/web-app/.projen/deps.json
+++ b/packages/blueprints/web-app/.projen/deps.json
@@ -14,6 +14,10 @@
       "type": "build"
     },
     {
+      "name": "@types/uuid",
+      "type": "build"
+    },
+    {
       "name": "@typescript-eslint/eslint-plugin",
       "version": "^5",
       "type": "build"
@@ -93,6 +97,11 @@
     },
     {
       "name": "projen",
+      "type": "runtime"
+    },
+    {
+      "name": "uuid",
+      "version": "8.3.2",
       "type": "runtime"
     }
   ],

--- a/packages/blueprints/web-app/.projen/tasks.json
+++ b/packages/blueprints/web-app/.projen/tasks.json
@@ -185,7 +185,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @caws-blueprint-util/blueprint-cli @caws-blueprint-util/projen-blueprint @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint json-schema npm-check-updates standard-version ts-node typescript @caws-blueprint-component/caws-environments @caws-blueprint-component/caws-source-repositories @caws-blueprint-component/caws-workflows @caws-blueprint-component/caws-workspaces @caws-blueprint-util/blueprint-utils @caws-blueprint/blueprints.blueprint"
+          "exec": "yarn upgrade @caws-blueprint-util/blueprint-cli @caws-blueprint-util/projen-blueprint @types/node @types/uuid @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint json-schema npm-check-updates standard-version ts-node typescript @caws-blueprint-component/caws-environments @caws-blueprint-component/caws-source-repositories @caws-blueprint-component/caws-workflows @caws-blueprint-component/caws-workspaces @caws-blueprint-util/blueprint-utils @caws-blueprint/blueprints.blueprint uuid"
         },
         {
           "exec": "npx projen"

--- a/packages/blueprints/web-app/.projenrc.ts
+++ b/packages/blueprints/web-app/.projenrc.ts
@@ -17,6 +17,7 @@ const blueprint = new ProjenBlueprint({
     '@caws-blueprint-component/caws-workflows',
     '@caws-blueprint-component/caws-environments',
     '@caws-blueprint-component/caws-workspaces',
+    'uuid@8.3.2',
   ],
   /* The description is a short string that helps people understand the purpose of the blueprint. */
   description: 'This blueprint creates and deploys a web application.',
@@ -24,7 +25,7 @@ const blueprint = new ProjenBlueprint({
   packageName: '@caws-blueprint/blueprints.web-app',
   publishingOrganization: 'blueprints',
   /* Build dependencies for this module. */
-  devDeps: ['ts-node', '@caws-blueprint-util/blueprint-cli', '@caws-blueprint-util/projen-blueprint'],
+  devDeps: ['ts-node', '@caws-blueprint-util/blueprint-cli', '@caws-blueprint-util/projen-blueprint', '@types/uuid'],
   /* Add release management to this project. */
   // release: undefined,
   keywords: ['blueprint', 'webapp', 'typescript', 'react', 'node'],

--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -35,6 +35,7 @@
     "@caws-blueprint-util/blueprint-cli": "0.0.x",
     "@caws-blueprint-util/projen-blueprint": "0.0.x",
     "@types/node": "^12",
+    "@types/uuid": "*",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
@@ -55,7 +56,8 @@
     "@caws-blueprint-component/caws-workspaces": "0.0.x",
     "@caws-blueprint-util/blueprint-utils": "0.0.x",
     "@caws-blueprint/blueprints.blueprint": "^0.0.x",
-    "projen": "*"
+    "projen": "*",
+    "uuid": "8.3.2"
   },
   "keywords": [
     "blueprint",

--- a/packages/blueprints/web-app/src/backend/create-stack.ts
+++ b/packages/blueprints/web-app/src/backend/create-stack.ts
@@ -1,5 +1,6 @@
 import { basename } from 'path';
 import { awscdk } from 'projen';
+import { v4 as uuidv4 } from 'uuid';
 const TYPESCRIPT_EXT = '.ts';
 
 export function getStackDefinition(params: {
@@ -134,12 +135,8 @@ app.synth();
   );
 }
 
-function getUniqueS3BucketName(repositoryName: string) {
-  return `${repositoryName.toLowerCase()}-${getSecondSinceEpoch()}`;
-}
-
-function getSecondSinceEpoch() {
-  return Math.floor(Date.now() / 1000);
+function getUniqueS3BucketName(bucketName: string) {
+  return `${bucketName.toLowerCase().slice(0, 30)}-${uuidv4().toString().slice(0, 16)}`;
 }
 
 export function getStackTestDefintion(appEntrypoint: string, backendStackName: string, frontendStackName: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,6 +530,7 @@ __metadata:
     "@caws-blueprint-util/projen-blueprint": 0.0.x
     "@caws-blueprint/blueprints.blueprint": ^0.0.x
     "@types/node": ^12
+    "@types/uuid": "*"
     "@typescript-eslint/eslint-plugin": ^5
     "@typescript-eslint/parser": ^5
     eslint: ^8
@@ -542,6 +543,7 @@ __metadata:
     standard-version: ^9
     ts-node: ^9
     typescript: ^4.5.5
+    uuid: 8.3.2
   languageName: unknown
   linkType: soft
 
@@ -1041,6 +1043,13 @@ __metadata:
   version: 0.0.30
   resolution: "@types/strip-json-comments@npm:0.0.30::__archiveUrl=https%3A%2F%2Ftemplate-721779663932.d.codeartifact.us-west-2.amazonaws.com%3A443%2Fnpm%2Fglobal-templates%2F%40types%2Fstrip-json-comments%2F-%2Fstrip-json-comments-0.0.30.tgz"
   checksum: 829ddd389645073f347c5b1924a8c34b8813af29756576e511c46f40e218193cf93ccbade62661d47fc70f707e98f410331729b8c20edfcb2e807d51df1ad4b7
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:*":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4::__archiveUrl=https%3A%2F%2Ftemplate-721779663932.d.codeartifact.us-west-2.amazonaws.com%3A443%2Fnpm%2Fglobal-templates%2F%40types%2Fuuid%2F-%2Fuuid-8.3.4.tgz"
+  checksum: 6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
   languageName: node
   linkType: hard
 
@@ -8183,6 +8192,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2::__archiveUrl=https%3A%2F%2Ftemplate-721779663932.d.codeartifact.us-west-2.amazonaws.com%3A443%2Fnpm%2Fglobal-templates%2Futil-deprecate%2F-%2Futil-deprecate-1.0.2.tgz"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2::__archiveUrl=https%3A%2F%2Ftemplate-721779663932.d.codeartifact.us-west-2.amazonaws.com%3A443%2Fnpm%2Fglobal-templates%2Fuuid%2F-%2Fuuid-8.3.2.tgz"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

Limits the S3 bucket length to under 63 chars regardless of the CFn stack name.

### Testing

How was this change tested?
Synth and preview. https://d19c38mdgtfwhc.cloudfront.net/
### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
