### PR TITLE
feat:(environmentType): remove enum value Staging

### DIFF
--- a/packages/blueprints/sam-serverless-app/README.md
+++ b/packages/blueprints/sam-serverless-app/README.md
@@ -118,7 +118,7 @@ This project has created the following Quokka.Codes resources:
   For more information on workflows, see the _Build, test, and deploy with workflows in Quokka_ section of the **Quokka User Guide**
 
 - Environment(s) - An abstraction of infrastructure resources for deploying applications. Environments can be used to organize deployment actions into
-  a development, staging, or production environment.
+  a production or non-production environment.
 
   For more information on environments, see the _Organizing deployments using environments_ section in the **Quokka User Guide**
 

--- a/packages/blueprints/sam-serverless-app/src/readmeContents.ts
+++ b/packages/blueprints/sam-serverless-app/src/readmeContents.ts
@@ -52,7 +52,7 @@ This project has created the following Quokka.Codes Resources:
 
   For more information on workflows, see the _Build, test, and deploy with workflows in Quokka_ section of the **Quokka User Guide**
 
-- Environment(s) - An abstraction of infrastructure resources for deploying applications. Environments can be used to organize deployment actions into a development, staging, or production environment.
+- Environment(s) - An abstraction of infrastructure resources for deploying applications. Environments can be used to organize deployment actions into a production or non-production environment
 
   For more information on environments, see the _Organizing deployments using environments_ section in the **Quokka User Guide**
 

--- a/packages/blueprints/web-app/README.md
+++ b/packages/blueprints/web-app/README.md
@@ -93,7 +93,7 @@ For more information on source repositories, see _Working with source repositori
 For more information on workflows, see _Build, test, and deploy with workflows_ in the **Quokka User Guide**
 
 - Environment(s) - An abstraction of infrastructure resources for deploying applications. Environments can be used to organize deployment actions into
-  a development, staging, or production environment.
+  a production or non-production environment.
 
 For more information on environments, see _Organizing deployments using environments_ in the **Quokka User Guide**.
 

--- a/packages/blueprints/web-app/src/readme-contents.ts
+++ b/packages/blueprints/web-app/src/readme-contents.ts
@@ -33,7 +33,7 @@ This project has created the following Quokka.Codes Resources:
 
   For more information on workflows, see _Build, test, and deploy with workflows_ in the **Quokka User Guide**
 
-  - Environment(s) - An abstraction of infrastructure resources for deploying applications. Environments can be used to organize deployment actions into a development, staging, or production environment.
+  - Environment(s) - An abstraction of infrastructure resources for deploying applications. Environments can be used to organize deployment actions into a production or non-production environment
 
   For more information on environments, see _Organizing deployments using environments_ in the **Quokka User Guide**.
 

--- a/packages/components/caws-environments/src/environment-definition.ts
+++ b/packages/components/caws-environments/src/environment-definition.ts
@@ -36,9 +36,9 @@ export type EnvironmentDefinition<T extends { [key: string]: AccountConnection<a
 
   /**
    * Environment type.
-   * only 'DEVELOPMENT' | 'STAGING' | 'PRODUCTION' are supported.
+   * only 'DEVELOPMENT' | 'PRODUCTION' are supported.
    */
-  environmentType: 'DEVELOPMENT' | 'STAGING' | 'PRODUCTION' | string;
+  environmentType: 'DEVELOPMENT' | 'PRODUCTION' | string;
 
   /**
    * Environment description.


### PR DESCRIPTION

### Description

We deploy team plans to change the EnvironmentType from `Staging|Development|Production` to `Production|NonProduction`. Since we transform the EnvironmentType `NonProduction` to `Development` at Fusi API layer and blueprints are calling Laplace directly, we just keep the EnvironmentType `Development` here. 

### Testing

- yarn build
- yarn synth
- `yarn blueprints:preview`
  - create projects with blueprints
  - verify environments are created
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
