### PR TITLE
fix(import-from-git): add a regex to validate input

### DIFF
--- a/packages/blueprints/import-from-git/package.json
+++ b/packages/blueprints/import-from-git/package.json
@@ -61,7 +61,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.962",
+  "version": "0.0.963-preview.0",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/import-from-git/src/blueprint.ts
+++ b/packages/blueprints/import-from-git/src/blueprint.ts
@@ -7,6 +7,7 @@ import {
   Options as ParentOptions,
   BlueprintSynthesisError as SynthError,
   BlueprintSynthesisErrorTypes as SynthErrorTypes,
+  BlueprintSynthesisErrorTypes,
 } from '@caws-blueprint/blueprints.blueprint';
 
 import defaults from './defaults.json';
@@ -26,7 +27,7 @@ const MAX_REPO_SIZE = max_repo_mb * (1024 * 1024);
 export interface Options extends ParentOptions {
   /**
    * Which Git repository do we clone? This should be a https URL.
-   * @validationRegex /^https://[a-zA-Z0-9_/.-]+$/
+   * @validationRegex /^https:\/\/[a-zA-Z0-9_\/.-]+$/
    * @validationMessage Git repository URL must start with https:// and contain only alphanumeric characters, dashes (-), periods (.), underscores, and forward slashes (/).
    */
   gitRepository: string;
@@ -51,6 +52,16 @@ export class Blueprint extends ParentBlueprint {
       ...defaults,
     };
     const options = Object.assign(typeCheck, options_);
+
+    //Do regex check that import-from-git input is a http: url
+    //^https:\/\/[a-zA-Z0-9_\/.-]+$
+    const httpRegex = new RegExp(/^https:\/\/[a-zA-Z0-9_\/.-]+$/);
+    if (!httpRegex.test(options.gitRepository)) {
+      this.throwSynthesisError({
+        name: BlueprintSynthesisErrorTypes.ValidationError,
+        message: 'Invalid input',
+      });
+    }
 
     const gitRepositoryName = options.gitRepository.split('/').pop()?.replace('.git', '');
     console.log(gitRepositoryName);


### PR DESCRIPTION
### Issue

Internal

### Description

Adds regex validation to the import-from-git blueprint input

### Testing

How was this change tested?
Published a preview version in gamma

### Additional context

Add any other context about the PR here.
n/a

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
