### PR TITLE
Enabling SAM Blueprint with Gradle to run unit tests out of the box

### DIFF
--- a/packages/blueprints/sam-serverless-app/src/models.ts
+++ b/packages/blueprints/sam-serverless-app/src/models.ts
@@ -1,3 +1,5 @@
+import { WriteFileOptions } from 'projen/lib/util';
+
 export interface RuntimeMapping {
   runtime: string;
   codeUri: string;
@@ -12,6 +14,7 @@ export interface RuntimeMapping {
   stepsToRunUnitTests: Array<string>;
   filesToCreate: Array<FileTemplate>;
   filesToOverride: Array<FileTemplate>;
+  filesToChangePermissionsFor: Array<FilePermissionChange>;
 }
 
 export interface FileTemplate {
@@ -22,6 +25,11 @@ export interface FileTemplate {
 export interface FileTemplateContext {
   repositoryRelativePath: string;
   lambdaFunctionName: string;
+}
+
+export interface FilePermissionChange {
+  resolvePath: (context: FileTemplateContext) => string;
+  newPermissions: WriteFileOptions;
 }
 
 /**

--- a/packages/blueprints/sam-serverless-app/src/runtimeMappings.ts
+++ b/packages/blueprints/sam-serverless-app/src/runtimeMappings.ts
@@ -21,6 +21,7 @@ export const runtimeMappings: Map<string, RuntimeMapping> = new Map([
       stepsToRunUnitTests: [],
       filesToCreate: [],
       filesToOverride: [],
+      filesToChangePermissionsFor: [],
     },
   ],
   [
@@ -46,10 +47,9 @@ export const runtimeMappings: Map<string, RuntimeMapping> = new Map([
           resolveContent(context: FileTemplateContext): string {
             return dedent`#!/usr/bin/env bash
 
-                          cd ${context.lambdaFunctionName}/HelloWorldFunction
-
                           echo "Running unit tests..."
-                          ./gradlew test`;
+                          GRADLE_DIR=${context.lambdaFunctionName}/HelloWorldFunction
+                          ./$GRADLE_DIR/gradlew test -p $GRADLE_DIR`;
           },
         },
       ],
@@ -97,6 +97,14 @@ export const runtimeMappings: Map<string, RuntimeMapping> = new Map([
           },
         },
       ],
+      filesToChangePermissionsFor: [
+        {
+          resolvePath(context: FileTemplateContext) {
+            return path.join(context.repositoryRelativePath, context.lambdaFunctionName, 'HelloWorldFunction', 'gradlew');
+          },
+          newPermissions: { executable: true },
+        },
+      ],
     },
   ],
   [
@@ -116,6 +124,7 @@ export const runtimeMappings: Map<string, RuntimeMapping> = new Map([
       stepsToRunUnitTests: [],
       filesToCreate: [],
       filesToOverride: [],
+      filesToChangePermissionsFor: [],
     },
   ],
   [
@@ -172,6 +181,7 @@ export const runtimeMappings: Map<string, RuntimeMapping> = new Map([
         },
       ],
       filesToOverride: [],
+      filesToChangePermissionsFor: [],
     },
   ],
 ]);


### PR DESCRIPTION
### Description

The purpose of this change is to enable unit tests and code coverage to be run out of the box with the SAM/Gradle Blueprint. As part of making this change, I also refactored the Blueprint code in order to make it easy to add new files, override existing file content, and change file permissions as needed. Those changes should make it easier to add unit test and code coverage support for SAM/Maven and SAM/NodeJS.

### Testing
1. Synthesized the changes locally and verified the content of the generated project
2. Deployed the Blueprint preview to our test org in Integ, created a project using this Blueprint, and verified that unit tests and code coverage are generated and produce reports: https://integ.stage.quokka.codes/organizations/test-team-blueprints/projects/EugenesGradleTest2/workflows/2400146d-8fc2-40c2-975a-c5948895163a/runs/31f72b81-5e9b-414f-b100-2cae9d9c06a9/view?activeTabId=visual&actionId=build_for_default_environment

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
