### PR TITLE
chore(blueprints): add a preview with prod endpoint script

### DIFF
--- a/packages/blueprints/blueprint-builder/package.json
+++ b/packages/blueprints/blueprint-builder/package.json
@@ -25,7 +25,8 @@
     "build:cache": "yarn build && yarn blueprint:build-ast && yarn blueprint:validate-options",
     "blueprint:synth": "blueprint synth ./ --outdir ./ --options ./src/defaults.json",
     "blueprint:synth:cache": "yarn build:cache && blueprint synth ./ --outdir ./ --options ./src/defaults.json --cache",
-    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints"
+    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints",
+    "blueprint:preview:prod": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints --endpoint public.api.quokka.codes"
   },
   "author": {
     "name": "caws-blueprints",

--- a/packages/blueprints/blueprint/package.json
+++ b/packages/blueprints/blueprint/package.json
@@ -25,7 +25,8 @@
     "build:cache": "yarn build && yarn blueprint:build-ast && yarn blueprint:validate-options",
     "blueprint:synth": "blueprint synth ./ --outdir ./ --options ./src/defaults.json",
     "blueprint:synth:cache": "yarn build:cache && blueprint synth ./ --outdir ./ --options ./src/defaults.json --cache",
-    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints"
+    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints",
+    "blueprint:preview:prod": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints --endpoint public.api.quokka.codes"
   },
   "author": {
     "name": "caws-blueprints",

--- a/packages/blueprints/frontend-showcase/package.json
+++ b/packages/blueprints/frontend-showcase/package.json
@@ -25,7 +25,8 @@
     "build:cache": "yarn blueprint:synth:cache",
     "blueprint:synth": "yarn blueprint:synth:cache",
     "blueprint:synth:cache": "yarn build && yarn blueprint:build-ast && yarn blueprint:validate-options && blueprint synth ./ --outdir ./ --options ./src/defaults.json --cache",
-    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints"
+    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints",
+    "blueprint:preview:prod": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints --endpoint public.api.quokka.codes"
   },
   "author": {
     "name": "blueprints",

--- a/packages/blueprints/import-from-git/package.json
+++ b/packages/blueprints/import-from-git/package.json
@@ -25,7 +25,8 @@
     "build:cache": "yarn build && yarn blueprint:build-ast && yarn blueprint:validate-options",
     "blueprint:synth": "blueprint synth ./ --outdir ./ --options ./src/defaults.json",
     "blueprint:synth:cache": "yarn build:cache && blueprint synth ./ --outdir ./ --options ./src/defaults.json --cache",
-    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints"
+    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints",
+    "blueprint:preview:prod": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints --endpoint public.api.quokka.codes"
   },
   "author": {
     "name": "caws-blueprints",

--- a/packages/blueprints/sam-serverless-app/package.json
+++ b/packages/blueprints/sam-serverless-app/package.json
@@ -24,7 +24,8 @@
     "build:cache": "yarn build && yarn blueprint:build-ast && yarn blueprint:validate-options",
     "blueprint:synth": "blueprint synth ./ --outdir ./ --options ./src/defaults.json",
     "blueprint:synth:cache": "yarn build:cache && blueprint synth ./ --outdir ./ --options ./src/defaults.json --cache",
-    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints"
+    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints",
+    "blueprint:preview:prod": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints --endpoint public.api.quokka.codes"
   },
   "author": {
     "name": "caws-blueprints",

--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -25,7 +25,8 @@
     "build:cache": "yarn build && yarn blueprint:build-ast && yarn blueprint:validate-options",
     "blueprint:synth": "blueprint synth ./ --outdir ./ --options ./src/defaults.json",
     "blueprint:synth:cache": "yarn build:cache && blueprint synth ./ --outdir ./ --options ./src/defaults.json --cache",
-    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints"
+    "blueprint:preview": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints",
+    "blueprint:preview:prod": "yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher blueprints --endpoint public.api.quokka.codes"
   },
   "author": {
     "name": "caws-blueprints",

--- a/packages/utils/projen-blueprint/src/blueprint.ts
+++ b/packages/utils/projen-blueprint/src/blueprint.ts
@@ -86,6 +86,11 @@ export class ProjenBlueprint extends typescript.TypeScriptProject {
       `yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher ${organization}`,
     );
 
+    this.setScript(
+      'blueprint:preview:prod',
+      `yarn bump:preview && yarn blueprint:synth:cache && yarn package && blueprint publish ./ --publisher ${organization} --endpoint public.api.quokka.codes`,
+    );
+
     //add additional metadata fields to package.json
     this.package.addField('mediaUrls', options.mediaUrls);
     //display name will be the package name by default


### PR DESCRIPTION
### Issue

preview, by default, publishes to the gamma endpoint. Add and propagate another script that explicitily publishes previews to the prod endpoint.

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
