### PR TITLE
fix(update): Update n-th check to 2.1.1

### DIFF
--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -69,7 +69,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.1088",
+  "version": "0.0.1089",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/blueprints/web-app/static-assets/frontend/package-lock.json
+++ b/packages/blueprints/web-app/static-assets/frontend/package-lock.json
@@ -5053,7 +5053,7 @@
         "boolbase": "^1.0.0",
         "css-what": "^3.2.1",
         "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "nth-check": "^2.1.1"
       }
     },
     "css-select-base-adapter": {
@@ -10201,14 +10201,6 @@
         "set-blocking": "^2.0.0"
       }
     },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "nwsapi": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
@@ -11253,7 +11245,7 @@
             "css-what": "^6.0.1",
             "domhandler": "^4.3.1",
             "domutils": "^2.8.0",
-            "nth-check": "^2.0.1"
+            "nth-check": "^2.1.1"
           }
         },
         "css-tree": {
@@ -12553,7 +12545,7 @@
             "css-what": "^6.0.1",
             "domhandler": "^4.3.1",
             "domutils": "^2.8.0",
-            "nth-check": "^2.0.1"
+            "nth-check": "^2.1.1"
           }
         },
         "css-what": {


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

Update n-th check to 2.1.1
### Testing

Tested e2e by creating a new project in integ and checking the endpoint generated by the workflow.
### Additional context

```

diff --git a/packages/blueprints/web-app/package.json b/packages/blueprints/web-app/package.json
index 427daca0..00181385 100644
--- a/packages/blueprints/web-app/package.json
+++ b/packages/blueprints/web-app/package.json
@@ -69,7 +69,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.1088",
+  "version": "0.0.1089",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"
@@ -80,4 +80,4 @@
     "got": "12.3.1"
   },
   "//": "~~ Generated by projen. To modify, edit .projenrc.js and run \"npx projen\"."
-}
\ No newline at end of file
+}
diff --git a/packages/blueprints/web-app/static-assets/frontend/package-lock.json b/packages/blueprints/web-app/static-assets/frontend/package-lock.json
index 2a1585c1..90c23ad1 100644
--- a/packages/blueprints/web-app/static-assets/frontend/package-lock.json
+++ b/packages/blueprints/web-app/static-assets/frontend/package-lock.json
@@ -5053,7 +5053,7 @@
         "boolbase": "^1.0.0",
         "css-what": "^3.2.1",
         "domutils": "^1.7.0",
-        "nth-check": "^1.0.2"
+        "nth-check": "^2.1.1"
       }
     },
     "css-select-base-adapter": {
@@ -10201,14 +10201,6 @@
         "set-blocking": "^2.0.0"
       }
     },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-      "requires": {
-        "boolbase": "~1.0.0"
-      }
-    },
     "nwsapi": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
@@ -11253,7 +11245,7 @@
             "css-what": "^6.0.1",
             "domhandler": "^4.3.1",
             "domutils": "^2.8.0",
-            "nth-check": "^2.0.1"
+            "nth-check": "^2.1.1"
           }
         },
         "css-tree": {
@@ -12553,7 +12545,7 @@
             "css-what": "^6.0.1",
             "domhandler": "^4.3.1",
             "domutils": "^2.8.0",
-            "nth-check": "^2.0.1"
+            "nth-check": "^2.1.1"
           }
         },
         "css-what": {
```


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
