### PR TITLE
blueprint for cdk deploy and bootstrap workflow actions

### DIFF
--- a/packages/components/caws-workflows/src/actions/action-cdk-bootstrap.ts
+++ b/packages/components/caws-workflows/src/actions/action-cdk-bootstrap.ts
@@ -1,0 +1,45 @@
+import { Blueprint } from '@caws-blueprint/blueprints.blueprint';
+import { WorkflowEnvironment } from '../environment/workflow-environment';
+import { WorkflowDefinition } from '../workflow/workflow';
+import { getDefaultActionIdentifier, ActionIdentifierAlias, ActionDefiniton } from './action';
+
+export interface CdkBootstrapInputConfiguration {
+  Artifacts?: string[];
+  Sources?: string[];
+  [key: string]: any;
+}
+
+export interface CdkBootstrapActionConfiguration {
+  [key: string]: string | undefined;
+  Region: string;
+  CloudFormationExecutionPolicies?: string;
+}
+
+export interface CdkBootstrapActionParameters {
+  inputs: CdkBootstrapInputConfiguration;
+  environment: WorkflowEnvironment;
+  computeName?: 'Linux.x86-64.Large' | 'Linux.x86-64.XLarge' | 'Linux.x86-64.2XLarge' | string;
+  configuration: CdkBootstrapActionConfiguration;
+  actionName: string;
+}
+
+export function addGenericCdkBootstrapAction(
+  params: CdkBootstrapActionParameters & {
+    blueprint: Blueprint;
+    workflow: WorkflowDefinition;
+  },
+): string {
+  const { blueprint, workflow, inputs, environment, configuration, computeName } = params;
+  const actionName = (params.actionName || 'BootstrapCdkStack').replace(new RegExp('-', 'g'), '_');
+
+  const cdkBootstrapAction: ActionDefiniton = {
+    Identifier: getDefaultActionIdentifier(ActionIdentifierAlias.cdkBootstrap, blueprint.context.environmentId),
+    Inputs: inputs,
+    Environment: environment,
+    Compute: computeName,
+    Configuration: configuration,
+  };
+  workflow.Actions = workflow.Actions || {};
+  workflow.Actions[actionName] = cdkBootstrapAction;
+  return actionName;
+}

--- a/packages/components/caws-workflows/src/actions/action-cdk-deploy.ts
+++ b/packages/components/caws-workflows/src/actions/action-cdk-deploy.ts
@@ -1,0 +1,49 @@
+import { Blueprint } from '@caws-blueprint/blueprints.blueprint';
+import { WorkflowEnvironment } from '../environment/workflow-environment';
+import { WorkflowDefinition } from '../workflow/workflow';
+import { getDefaultActionIdentifier, ActionIdentifierAlias, ActionDefiniton } from './action';
+
+export interface CdkDeployInputConfiguration {
+  Artifacts?: string[];
+  Sources?: string[];
+  [key: string]: any;
+}
+
+export interface CdkDeployActionConfiguration {
+  [key: string]: string | undefined;
+  StackName: string;
+  Region?: string;
+  Tags?: string;
+  Context?: string;
+  CfnOutputVariables?: string;
+  CdkRootLocation?: string;
+}
+
+export interface CdkDeployActionParameters {
+  inputs: CdkDeployInputConfiguration;
+  environment: WorkflowEnvironment;
+  computeName?: 'Linux.x86-64.Large' | 'Linux.x86-64.XLarge' | 'Linux.x86-64.2XLarge' | string;
+  configuration: CdkDeployActionConfiguration;
+  actionName: string;
+}
+
+export function addGenericCdkDeployAction(
+  params: CdkDeployActionParameters & {
+    blueprint: Blueprint;
+    workflow: WorkflowDefinition;
+  },
+): string {
+  const { blueprint, workflow, inputs, environment, configuration, computeName } = params;
+  const actionName = (params.actionName || 'DeployCdkStack').replace(new RegExp('-', 'g'), '_');
+
+  const cdkDeployAction: ActionDefiniton = {
+    Identifier: getDefaultActionIdentifier(ActionIdentifierAlias.cdkDeploy, blueprint.context.environmentId),
+    Inputs: inputs,
+    Environment: environment,
+    Compute: computeName,
+    Configuration: configuration,
+  };
+  workflow.Actions = workflow.Actions || {};
+  workflow.Actions[actionName] = cdkDeployAction;
+  return actionName;
+}

--- a/packages/components/caws-workflows/src/actions/action.ts
+++ b/packages/components/caws-workflows/src/actions/action.ts
@@ -5,6 +5,8 @@
 
 import { WorkflowEnvironment } from '../environment/workflow-environment';
 import { BuildActionConfiguration } from './action-build';
+import { CdkBootstrapActionConfiguration } from './action-cdk-bootstrap';
+import { CdkDeployActionConfiguration } from './action-cdk-deploy';
 import { CfnDeployActionConfiguration } from './action-cfn-deploy';
 import { TestActionConfiguration } from './action-test-reports';
 
@@ -12,6 +14,8 @@ export enum ActionIdentifierAlias {
   build = 'build',
   deploy = 'deploy',
   test = 'test',
+  cdkDeploy = 'cdkDeploy',
+  cdkBootstrap = 'cdkBootstrap',
 }
 
 const ACTION_IDENTIFIERS: { [key: string]: { default: string; prod: string } } = {
@@ -27,15 +31,29 @@ const ACTION_IDENTIFIERS: { [key: string]: { default: string; prod: string } } =
     default: 'aws/cfn-deploy-gamma@v1',
     prod: 'aws/cfn-deploy@v1',
   },
+  cdkDeploy: {
+    default: 'aws/cdk-deploy-gamma@v1',
+    prod: 'aws/cdk-deploy@v1',
+  },
+  cdkBootstrap: {
+    default: 'aws/cdk-bootstrap-gamma@v1',
+    prod: 'aws/cdk-bootstrap@v1',
+  },
 };
 
 export function getDefaultActionIdentifier(alias: ActionIdentifierAlias, environmentIdentifier: string = 'default'): string | undefined {
   return ACTION_IDENTIFIERS[alias]?.[environmentIdentifier] ?? ACTION_IDENTIFIERS[alias]?.default;
 }
 
-type TypeSupportedActions = BuildActionConfiguration | CfnDeployActionConfiguration | TestActionConfiguration;
+type TypeSupportedActions =
+  | BuildActionConfiguration
+  | CfnDeployActionConfiguration
+  | TestActionConfiguration
+  | CdkDeployActionConfiguration
+  | CdkBootstrapActionConfiguration;
 export interface ActionDefiniton {
   Identifier?: string;
+  Compute?: string;
   Configuration?: TypeSupportedActions;
   DependsOn?: string[];
   Inputs?: InputsDefinition;

--- a/packages/components/caws-workflows/src/index.ts
+++ b/packages/components/caws-workflows/src/index.ts
@@ -12,4 +12,6 @@ export * from './environment/workflow-environment';
 export * from './actions/action';
 export * from './actions/action-build';
 export * from './actions/action-cfn-deploy';
+export * from './actions/action-cdk-deploy';
+export * from './actions/action-cdk-bootstrap';
 export * from './actions/action-test-reports';


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

Implementing cdk-deploy and cdk-bootstrap templates. The primary use of these are to refactor the webapp blueprint (and any other projects needing cdk actions in workflows). 

### Testing

`yarn blueprint:synth`

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
