### PR TITLE
feat(projen-blueprint): update the blueprint model to always include all static assets

### DIFF
--- a/packages/blueprints/blueprint-builder/package.json
+++ b/packages/blueprints/blueprint-builder/package.json
@@ -71,7 +71,8 @@
   ],
   "displayName": "Blueprint Builder",
   "files": [
-    "static-assets"
+    "static-assets",
+    "lib"
   ],
   "resolutions": {
     "@types/responselike": "1.0.0",

--- a/packages/blueprints/blueprint/package.json
+++ b/packages/blueprints/blueprint/package.json
@@ -64,7 +64,8 @@
   ],
   "displayName": "Empty project",
   "files": [
-    "static-assets"
+    "static-assets",
+    "lib"
   ],
   "resolutions": {
     "@types/responselike": "1.0.0",

--- a/packages/blueprints/sam-serverless-app/package.json
+++ b/packages/blueprints/sam-serverless-app/package.json
@@ -66,7 +66,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.1215",
+  "version": "0.0.1216-preview.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",
@@ -113,7 +113,8 @@
   ],
   "displayName": "Serverless application model (SAM) API",
   "files": [
-    "static-assets"
+    "static-assets",
+    "lib"
   ],
   "resolutions": {
     "@types/responselike": "1.0.0",

--- a/packages/blueprints/test-blueprint/package.json
+++ b/packages/blueprints/test-blueprint/package.json
@@ -68,7 +68,8 @@
   ],
   "displayName": "Test Blueprint [Internal]",
   "files": [
-    "static-assets"
+    "static-assets",
+    "lib"
   ],
   "resolutions": {
     "@types/responselike": "1.0.0",

--- a/packages/components/caws-environments/package.json
+++ b/packages/components/caws-environments/package.json
@@ -45,7 +45,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/components/caws-issues/package.json
+++ b/packages/components/caws-issues/package.json
@@ -45,7 +45,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/components/caws-source-repositories/package.json
+++ b/packages/components/caws-source-repositories/package.json
@@ -50,7 +50,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/components/caws-workflows/package.json
+++ b/packages/components/caws-workflows/package.json
@@ -47,7 +47,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/components/caws-workspaces/package.json
+++ b/packages/components/caws-workspaces/package.json
@@ -46,7 +46,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/utils/blueprint-cli/package.json
+++ b/packages/utils/blueprint-cli/package.json
@@ -62,7 +62,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/packages/utils/blueprint-utils/package.json
+++ b/packages/utils/blueprint-utils/package.json
@@ -42,7 +42,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/utils/projen-blueprint-component/package.json
+++ b/packages/utils/projen-blueprint-component/package.json
@@ -41,7 +41,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/utils/projen-blueprint/package.json
+++ b/packages/utils/projen-blueprint/package.json
@@ -43,7 +43,7 @@
   },
   "main": "lib/index.js",
   "license": "MIT",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "types": "lib/index.d.ts",
   "preferGlobal": true,
   "resolutions": {

--- a/packages/utils/projen-blueprint/src/blueprint.ts
+++ b/packages/utils/projen-blueprint/src/blueprint.ts
@@ -98,6 +98,6 @@ export class ProjenBlueprint extends typescript.TypeScriptProject {
     this.package.addField('displayName', options.displayName || this.package.packageName);
 
     // force the static assets to always be fully included, regardless of .npmignores
-    this.package.addField('files', ['static-assets']);
+    this.package.addField('files', ['static-assets', 'lib']);
   }
 }


### PR DESCRIPTION
Blueprints get packaged as npm packages and often depend on arbitrary files placed in the `./static-assets/` folder

### Issue
The problem is that sometimes you want to include a `.npmignore` file in the static assets. This messes with the files that actually make it into the blueprint package that gets published.

### Description

These changes update the blueprint projen component to generate a package.json that explicitly always includes all files in the `static-assets` folder. This was tested on SPA.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
