### PR TITLE
Remove --updateSnapshot from test task

### DIFF
--- a/packages/blueprints/sam-serverless-app/.projen/tasks.json
+++ b/packages/blueprints/sam-serverless-app/.projen/tasks.json
@@ -131,7 +131,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --all --updateSnapshot"
+          "exec": "jest --passWithNoTests"
         }
       ]
     },


### PR DESCRIPTION
### Issue

https://sim.amazon.com/issues/BLUEPRINTS-3730

### Description

Today, `yarn test` updates snapshots when they differ. We do not want this; we'd rather fail the unit test.
Newer versions of Projen allow us to change this behavior, but this project's version does not.
This PR removes `--updateSnapshot` in the best way I can find without upgrading Projen.

### Testing

`yarn build` on the whole project and verify that existing Blueprints' `tasks.json` are either unchanged or have only the desired change.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
