### PR TITLE
fix(projen-blueprint): set consumers to gitignore test snapshot infra code

### DIFF
--- a/packages/utils/projen-blueprint/src/test-snapshot.ts
+++ b/packages/utils/projen-blueprint/src/test-snapshot.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { JsonFile, Project, SourceCode } from 'projen';
+import { JsonFile, Project, TextFile } from 'projen';
 import { BlueprintSnapshotConfiguration } from './blueprint';
 import { generateFilesTs } from './snapshot-testing/gen-files';
 import { generateOutdirTs } from './snapshot-testing/gen-outdir';
@@ -37,8 +37,13 @@ export function generateTestSnapshotInfraFiles(project: Project, testingConfig: 
   fs.mkdirSync(infraDir);
 
   files.forEach(([fileContent, fileName]) => {
-    const sourceCodeObj = new SourceCode(project, fileName, { readonly: false });
-    fileContent.split('\n').forEach(line => sourceCodeObj.line(line));
+    // These are source code files, but we use `TextFile` instead of `SourceCode` because
+    // the former lets us choose to not commit these.
+    const fileObj = new TextFile(project, fileName, {
+      committed: false,
+      marker: false, // we add our own marker
+    });
+    fileContent.split('\n').forEach(line => fileObj.addLine(line));
   });
 
   const configsDir = path.join(SRC_DIR, CONFIGS_SUBDIR);


### PR DESCRIPTION
### Issue

https://sim.amazon.com/issues/BLUEPRINTS-3730

### Description

Right now, on main, when a consumer blueprint enables snapshot testing, we generate source code files that become part of the blueprint and are committed to its git repo. However, it may be better to set these files to be .gitignored, since the customer does not own them and is expected to not change them.

### Testing

By rebuilding SAM blueprint, which has snapshot testing enabled, and seeing the effects.

### Additional context

n/a

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
