### PR TITLE
fix(projen-blueprint): rename snapshot driver file

### DIFF
--- a/packages/utils/projen-blueprint/src/test-snapshot.ts
+++ b/packages/utils/projen-blueprint/src/test-snapshot.ts
@@ -9,7 +9,7 @@ const SRC_DIR = 'src';
 const INFRA_SUBDIR = 'testSnapshotInfrastructure';
 const CONFIGS_SUBDIR = 'snapshot-configurations';
 const DEFAULT_TEST_CONFIG_FILENAME = 'default-config.json';
-const SNAPSHOTS_SPEC_FILENAME = 'blueprint-snapshots.spec.ts';
+const SNAPSHOTS_SPEC_FILENAME = 'blueprint-snapshot-driver.spec.ts';
 
 export function generateTestSnapshotInfraFiles(project: Project, testingConfig: BlueprintSnapshotConfiguration) {
   // If you add or change any files here, remember to update `cleanUpTestSnapshotInfraFiles()`


### PR DESCRIPTION
### Issue

https://sim.amazon.com/issues/BLUEPRINTS-3730

### Description

Rename a Projen-owned file, on Alex's advice.

### Testing

Rebuilt SAM blueprint and reran its tests.

### Additional context

n/a

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
