### PR TITLE
fix(github-action): Run workflow on merge commit, not on base

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [assigned, opened, synchronize, reopened]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
We want to run build/test on the content of pull requests, but we discovered that build/test was running against `main` instead.

Our GitHub action workflow was using `pull_request_target`. The documentation states:

> This event runs in the context of the base of the pull request, rather than
> in the context of the merge commit, as the `pull_request` event does.
> ...
> Avoid using this event if you need to build or run code from the pull request.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

Now I switch to `pull_request`, which:

> Runs your workflow when activity on a pull request in the workflow's repository occurs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
