### PR TITLE
fix(caws-workflows): do not mutate empty workflow template

### DIFF
--- a/packages/blueprints/sam-serverless-app/src/blueprint.ts
+++ b/packages/blueprints/sam-serverless-app/src/blueprint.ts
@@ -11,7 +11,7 @@ import {
   addGenericBuildAction,
   addGenericCompute,
   addGenericCloudFormationDeployAction,
-  emptyWorkflow,
+  makeEmptyWorkflow,
   AutoDiscoverReportDefinition,
 } from '@caws-blueprint-component/caws-workflows';
 import { SampleDir, SampleFile } from 'projen';
@@ -225,7 +225,7 @@ export class Blueprint extends ParentBlueprint {
     const schemaVersion = '1.0';
 
     const workflowDefinition: WorkflowDefinition = {
-      ...emptyWorkflow,
+      ...makeEmptyWorkflow(),
       SchemaVersion: schemaVersion,
       Name: name,
     };

--- a/packages/components/caws-workflows/src/samples/empty.ts
+++ b/packages/components/caws-workflows/src/samples/empty.ts
@@ -1,13 +1,15 @@
 import { ComputeType, ComputeFleet } from '../workflow/compute';
 import { WorkflowDefinition } from '../workflow/workflow';
 
-export const emptyWorkflow: WorkflowDefinition = {
-  Name: 'build',
-  SchemaVersion: '1.0',
-  Triggers: [],
-  Compute: {
-    Type: ComputeType.EC2,
-    Fleet: ComputeFleet.LINUX_X86_64_LARGE,
-  },
-  Actions: {},
-};
+export function makeEmptyWorkflow(): WorkflowDefinition {
+  return {
+    Name: 'build',
+    SchemaVersion: '1.0',
+    Triggers: [],
+    Compute: {
+      Type: ComputeType.EC2,
+      Fleet: ComputeFleet.LINUX_X86_64_LARGE,
+    },
+    Actions: {},
+  };
+}


### PR DESCRIPTION
### Issue

n/a

### Description

We end up writing unexpected workflows, such as having three identical triggers:
https://github.com/aws/caws-blueprints/commit/a3925b874e131866d64ea79ffe4377ffc755b65a#diff-d9b057bd1c47c9fe91e22fa444691686169a03ff60e2608335b87ed9e09baa34R16
... because we're mutating the _empty_ template and reusing it.

### Testing

I ran snapshot tests on SAM Serverless template and verified that duplicated triggers are no longer present.

### Additional context

n/a

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
