### PR TITLE
feat(blueprint-cli): Add CLI support for snapshot testing

### DIFF
--- a/packages/utils/blueprint-cli/src/index.ts
+++ b/packages/utils/blueprint-cli/src/index.ts
@@ -33,6 +33,16 @@ yargs
           type: 'string',
           demandOption: true,
         })
+        .option('outdirExact', {
+          default: false,
+          describe: 'use given `outdir` exactly, without adding entropy and without using a stable directory',
+          type: 'boolean',
+        })
+        .option('enableStableSynthesis', {
+          default: true,
+          describe: 'in addition to regular synthesis, synthesize in a stable directory using a stable cache',
+          type: 'boolean',
+        })
         .option('defaults', {
           description: 'path to defaults.json to feed default values into synthesis',
           type: 'string',
@@ -44,7 +54,7 @@ yargs
         });
     },
     handler: async (argv: SynthesizeOptions): Promise<void> => {
-      await synth(log, argv.blueprint, argv.outdir, argv.cache, argv.options);
+      await synth(log, argv);
       process.exit(0);
     },
   })


### PR DESCRIPTION
This change is to facilitate Blueprint snapshot testing invoking the CLI to synthesize the blueprint, rather than instantiating the Blueprint class directly:
https://quip-amazon.com/9Gj8AfGtvjd2/Decision-Testing-strategy-for-Blueprints#temp:C:WTec3f3e30e75954befa44ff4e61

Tested by adding a temporary script to SAM Blueprint's `package.json`:

    "blueprint:synth:snapshots": "blueprint synth ./ --outdir ./synth-for-snapshots --outdirExact true --enableStableSynthesis false --options ./src/defaults.json",

Running this command synthesized the blueprint at the expected place on the filesystem.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
