### PR TITLE
feat(projen-blueprint): Snapshot testing invokes CLI rather than inst…

### DIFF
--- a/packages/utils/projen-blueprint/src/snapshot-testing/gen-infra.ts
+++ b/packages/utils/projen-blueprint/src/snapshot-testing/gen-infra.ts
@@ -73,8 +73,10 @@ export function getAllBlueprintSnapshottedFilenames(outdir: string) {
   return getAllNestedFiles(outdir, outdir);
 }
 
-export function prepareNewOutdir(): string {
-  const outdir = fs.mkdtempSync('unittest-outdir-');
+// We'll incorporate the given hint into the filename, to help disambiguate
+// if the consumer wants multiple directories.
+export function prepareTempDir(hint: string): string {
+  const outdir = fs.mkdtempSync(\`outdir-test-\${hint}\`);
   console.debug(\`outdir: \${outdir}\`);
 
   // Clean up the directory. If we don't clean up, then \`mkdirSync\` will throw an error.
@@ -85,7 +87,7 @@ export function prepareNewOutdir(): string {
   return outdir;
 }
 
-export function cleanUpOutdir(outdir: string): void {
+export function cleanUpTempDir(outdir: string): void {
   console.debug(\`cleaning up outdir: \${outdir}\`);
   fs.rmSync(outdir, { force: true, recursive: true });
 }

--- a/packages/utils/projen-blueprint/src/snapshot-testing/gen-spec.ts
+++ b/packages/utils/projen-blueprint/src/snapshot-testing/gen-spec.ts
@@ -1,36 +1,56 @@
 export function generateSpecTs(infraSubdir: string): string {
   return `
+import * as cproc from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 
-import { Blueprint, Options } from './blueprint';
+import { Options } from './blueprint';
 import {
   allTestConfigs,
-  cleanUpOutdir,
+  cleanUpTempDir,
   getAllBlueprintSnapshottedFilenames,
-  prepareNewOutdir
+  prepareTempDir,
 } from './${infraSubdir}/infrastructure';
 
 describe('Blueprint snapshots for test configurations', () => {
   allTestConfigs().forEach(testConfig => {
     describe(\`\${testConfig.name} configuration\`, () => {
-      let blueprint;
+      let blueprintOutdir;
+      let configOutdir;
 
       beforeAll(() => {
-        const outdir = prepareNewOutdir();
+        blueprintOutdir = prepareTempDir('blueprint');
+
+        // Write options to a file, as that's what the Blueprints CLI consumes.
         const options: Options = {
           ...testConfig.config,
-          outdir,
+          outdir: blueprintOutdir,
         };
-        blueprint = new Blueprint(options);
-        blueprint.synth();
+        configOutdir = prepareTempDir('config');
+        const configOutfile = path.join(configOutdir, 'snap-config.json');
+        fs.writeFileSync(configOutfile, JSON.stringify(options));
+        console.debug(\`Wrote snapshot config to \${configOutfile}\`);
+
+        // Synthesize using the Blueprint CLI
+        const synthCmd = \`npx blueprint synth ./ --outdirExact true --enableStableSynthesis false --outdir \${blueprintOutdir} --options \${configOutfile}\`;
+        console.debug(\`Synthesis command: \${synthCmd}\`);
+
+        let synthBuffer;
+        try {
+          synthBuffer = cproc.execSync(synthCmd);
+        } catch (e) {
+          console.log(\`Failed synthesis output:\\n\${synthBuffer}\`);
+          throw e;
+        }
       });
 
       afterAll(() => {
-        cleanUpOutdir(blueprint.outdir);
+        cleanUpTempDir(blueprintOutdir);
+        cleanUpTempDir(configOutdir);
       });
 
       it('matches snapshots', async () => {
-        for await (const snappedFile of getAllBlueprintSnapshottedFilenames(blueprint.outdir)) {
+        for await (const snappedFile of getAllBlueprintSnapshottedFilenames(blueprintOutdir)) {
           await expect(fs.readFileSync(snappedFile.absPath, { encoding: 'utf-8' })).toMatchSnapshot(snappedFile.relPath);
         }
       });


### PR DESCRIPTION
### Issue

n/a

### Description

As documented in
https://quip-amazon.com/9Gj8AfGtvjd2/Decision-Testing-strategy-for-Blueprints#temp:C:WTec3f3e30e75954befa44ff4e61
and agreed on with Alex.

This does not affect any existing functionality because we do not have
snapshot testing enabled in any blueprint.

### Testing

GitHub build action: https://github.com/philipmw/caws-blueprints/actions/runs/3569247413/jobs/5999010399

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
