### PR TITLE
fix(projen-blueprint): snapshot tests pass options to CLI properly

### DIFF
--- a/packages/utils/projen-blueprint/src/snapshot-testing/gen-spec.ts
+++ b/packages/utils/projen-blueprint/src/snapshot-testing/gen-spec.ts
@@ -32,7 +32,7 @@ describe('Blueprint snapshots for test configurations', () => {
         console.debug(\`Wrote snapshot config to \${configOutfile}\`);
 
         // Synthesize using the Blueprint CLI
-        const synthCmd = \`npx blueprint synth ./ --outdirExact true --enableStableSynthesis false --outdir \${blueprintOutdir} --options \${configOutfile}\`;
+        const synthCmd = \`npx blueprint synth ./ --outdirExact true --enableStableSynthesis false --outdir \${blueprintOutdir} --defaults \${configOutfile}\`;
         console.debug(\`Synthesis command: \${synthCmd}\`);
 
         let synthBuffer;


### PR DESCRIPTION
### Issue

n/a

### Description

This follows the change to CLI in commit 16acca0c5cc12d8120815c4201bc0552c5d4efe1.

### Testing

Regenerated SAM snapshots and verified manually that they are correct.

### Additional context

n/a

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
