### PR TITLE
fix(projen-blueprint): run tests with `--ci` flag

### DIFF
--- a/packages/utils/projen-blueprint/src/blueprint.ts
+++ b/packages/utils/projen-blueprint/src/blueprint.ts
@@ -95,7 +95,7 @@ export class ProjenBlueprint extends typescript.TypeScriptProject {
         }
       }
       if (finalOpts.jest) {
-        testTask.exec('jest --passWithNoTests');
+        testTask.exec('jest --ci --passWithNoTests');
       }
     }
 


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

This causes snapshot tests to be more strict and fail when a new snapshot is encountered.

https://jestjs.io/docs/cli#--ci

To update snapshots intentionally, one should run `yarn test:update`.

### Testing

On SAM Blueprint.

### Additional context

n/a

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
