### PR TITLE
fix(caws-workflows): typo and preserve backwards compatibility

### DIFF
--- a/packages/components/caws-source-repositories/src/static-assets.ts
+++ b/packages/components/caws-source-repositories/src/static-assets.ts
@@ -46,7 +46,21 @@ export class SubstitionAsset extends StaticAsset {
     super(path);
   }
 
+  /**
+   * @deprecated
+   * @param subsitution
+   * @returns
+   */
   subsitite(subsitution: any): string {
+    return this.substitute(subsitution);
+  }
+
+  /**
+   * Use Mustache subsitution across this asset.
+   * @param subsitution
+   * @returns
+   */
+  substitute(subsitution: any): string {
     return Mustache.render(this.content().toString(), subsitution);
   }
 }

--- a/packages/components/caws-workflows/src/samples/empty.ts
+++ b/packages/components/caws-workflows/src/samples/empty.ts
@@ -13,3 +13,5 @@ export function makeEmptyWorkflow(): WorkflowDefinition {
     Actions: {},
   };
 }
+
+export const emptyWorkflow = makeEmptyWorkflow();


### PR DESCRIPTION
### Issue

- [x] fixes: https://github.com/aws/caws-blueprints/issues/294
- [x] fixes: issue in [this PR](https://github.com/aws/caws-blueprints/commit/5964f07d66c4d3b20ae0e67e5751c7984a9d2500#diff-8290f84d1ac2a6b566146f73b1f6c5632d8b126befcd7534ab415deddba6cb78L4-L13) that accidentally removes the `emptyWorkflow` in a backwards incompatible way.



### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
