### PR TITLE
fix(blueprint-cli): Change organizationName to spaceName for blueprin…

### DIFF
--- a/packages/blueprints/blueprint-builder/package.json
+++ b/packages/blueprints/blueprint-builder/package.json
@@ -64,7 +64,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.0.1205",
+  "version": "0.0.1206",
   "types": "lib/index.d.ts",
   "mediaUrls": [
     "https://d1.awsstatic.com/logos/aws-logo-lockups/poweredbyaws/PB_AWS_logo_RGB_stacked_REV_SQ.91cd4af40773cbfbd15577a3c2b8a346fe3e8fa2.png"

--- a/packages/utils/blueprint-cli/src/publish.ts
+++ b/packages/utils/blueprint-cli/src/publish.ts
@@ -86,7 +86,7 @@ export async function publish(log: pino.BaseLogger, blueprint: string, publisher
     {
       query: `mutation {
         createBlueprintUploadUrl(input: {
-          organizationName: "${publisher}",
+          spaceName: "${publisher}",
           publisher: "${publisher}",
           packageSignature: "${packageSignature}",
           name: "${friendlyBlueprintName}",
@@ -97,7 +97,7 @@ export async function publish(log: pino.BaseLogger, blueprint: string, publisher
     {
       headers: {
         'authority': endpoint,
-        'accespt': 'application/json',
+        'accept': 'application/json',
         'origin': `https://${endpoint}`,
         'cookie': cookie,
         'anti-csrftoken-a2z': indentity.csrfToken,


### PR DESCRIPTION

### Issue

Issue number, if available, prefixed with "#"

### Description

Change organizationName to spaceName for blueprint publish

### Testing
`yarn install && yarn build`
`bumped up the version and published preview version of blueprint-builder`
`prepush hook`
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
