### PR TITLE
feat(sam-serverless-app): Add IDE configurations for Node runtime

### DIFF
--- a/packages/blueprints/sam-serverless-app/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
+++ b/packages/blueprints/sam-serverless-app/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
@@ -1653,6 +1653,45 @@ Outputs:
     Value: !GetAtt gradle-test-fn-nameFunctionRole.Arn"
 `;
 
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.cloud9/runners/SAM Project Builder.run 1`] = `
+"{
+  "script": [
+    "for directory in /projects/* ; do",
+    "  if [ -d \\"$directory/.cloud9/runners\\" ]; then",
+    "    REPOSITORY_DIR=$directory",
+    "  fi",
+    "done",
+    "cd $REPOSITORY_DIR",
+    "sam build"
+  ],
+  "info": "This runner builds the Serverless Application Model (SAM) Project."
+}
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.cloud9/runners/SAM Project Test Runner.run 1`] = `
+"{
+  "script": [
+    "for directory in /projects/* ; do",
+    "  if [ -d \\"$directory/.cloud9/runners\\" ]; then",
+    "    REPOSITORY_DIR=$directory",
+    "  fi",
+    "done",
+    "cd $REPOSITORY_DIR",
+    "for directory in \\"$REPOSITORY_DIR\\"/* ; do",
+    "  if [ -d \\"$directory/hello-world/tests\\" ]; then",
+    "    TESTS_DIR=$directory",
+    "  fi",
+    "done",
+    "echo $TESTS_DIR",
+    "cd $TESTS_DIR/hello-world",
+    "npm install",
+    "npm run test"
+  ],
+  "info": "This runner installs the dependencies, and executes the tests inside the hello-world directory."
+}"
+`;
+
 exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.codecatalyst/scripts/run-tests.sh 1`] = `
 "#!/usr/bin/env bash
 
@@ -1715,6 +1754,218 @@ Actions:
         template: .aws-sam/build/packaged.yaml
         no-fail-on-empty-changeset: "1"
         capabilities: CAPABILITY_IAM,CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.idea/externalDependencies.xml 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="ExternalDependencies">
+        <plugin id="Docker" />
+        <plugin id="JavaScript" />
+        <plugin id="JavaScriptDebugger" />
+        <plugin id="aws.toolkit" />
+        <plugin id="NodeJS" />
+        <plugin id="org.jetbrains.plugins.yaml" />
+    </component>
+</project>
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.idea/runConfigurations/all_tests_coverage.xml 1`] = `
+"<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="all tests coverage" type="js.build_tools.npm">
+        <package-json value="$PROJECT_DIR$/SamFirstEndpoint/hello-world/package.json" />
+        <command value="run" />
+        <scripts>
+            <script value="coverage" />
+        </scripts>
+        <node-interpreter value="project" />
+        <envs />
+        <method v="2">
+            <option name="NpmBeforeRunTask" enabled="true">
+                <package-json value="$PROJECT_DIR$/SamFirstEndpoint/hello-world/package.json" />
+                <command value="run" />
+                <scripts>
+                    <script value="test" />
+                </scripts>
+                <node-interpreter value="project" />
+                <envs />
+            </option>
+        </method>
+    </configuration>
+</component>
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.idea/runConfigurations/sam_build.xml 1`] = `
+"<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="sam build" type="ShConfigurationType">
+        <option name="SCRIPT_TEXT" value="sam build" />
+        <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+        <option name="SCRIPT_PATH" value="" />
+        <option name="SCRIPT_OPTIONS" value="" />
+        <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+        <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+        <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+        <option name="INTERPRETER_PATH" value="" />
+        <option name="INTERPRETER_OPTIONS" value="" />
+        <option name="EXECUTE_IN_TERMINAL" value="false" />
+        <option name="EXECUTE_SCRIPT_FILE" value="false" />
+        <envs />
+        <method v="2" />
+    </configuration>
+</component>
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.idea/runConfigurations/sam_local_invoke.xml 1`] = `
+"<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="sam local invoke" type="ShConfigurationType">
+        <option name="SCRIPT_TEXT" value="sam local invoke SamFirstEndpointFunction --event SamFirstEndpoint/events/event.json" />
+        <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+        <option name="SCRIPT_PATH" value="" />
+        <option name="SCRIPT_OPTIONS" value="" />
+        <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+        <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+        <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+        <option name="INTERPRETER_PATH" value="" />
+        <option name="INTERPRETER_OPTIONS" value="" />
+        <option name="EXECUTE_IN_TERMINAL" value="false" />
+        <option name="EXECUTE_SCRIPT_FILE" value="false" />
+        <envs />
+        <method v="2" />
+    </configuration>
+</component>
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.idea/runConfigurations/sam_start_local_api.xml 1`] = `
+"<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="sam start local api" type="ShConfigurationType">
+        <option name="SCRIPT_TEXT" value="sam local start-api" />
+        <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+        <option name="SCRIPT_PATH" value="" />
+        <option name="SCRIPT_OPTIONS" value="" />
+        <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+        <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+        <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+        <option name="INTERPRETER_PATH" value="" />
+        <option name="INTERPRETER_OPTIONS" value="" />
+        <option name="EXECUTE_IN_TERMINAL" value="false" />
+        <option name="EXECUTE_SCRIPT_FILE" value="false" />
+        <envs />
+        <method v="2" />
+    </configuration>
+</component>
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.vscode/extensions.json 1`] = `
+"{
+    "recommendations": [
+        "redhat.vscode-yaml",
+        "AmazonWebServices.aws-toolkit-vscode"
+    ]
+}
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.vscode/launch.json 1`] = `
+"{
+    "version": "1.0.0",
+    "configurations": [
+        {
+            "name": "Launch local sam API",
+            "request": "launch",
+            "type": "chrome",
+            "url": "http://localhost:3000",
+            "webRoot": "\${workspaceFolder}/SamFirstEndpoint/hello-world",
+            "preLaunchTask": "sam: start api"
+        },
+        {
+            "name": "Debug current test file",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": [
+                "\${workspaceRoot}/SamFirstEndpoint/hello-world/node_modules/.bin/mocha",
+                "--inspect-brk",
+                "\${relativeFile}",
+            ],
+            "console": "integratedTerminal",
+        },
+        {
+            "name": "Debug all test files",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": [
+                "\${workspaceRoot}/SamFirstEndpoint/hello-world/node_modules/.bin/mocha",
+                "\${workspaceRoot}/SamFirstEndpoint/hello-world/tests/**/*"
+            ],
+            "console": "integratedTerminal",
+        },
+    ]
+}
+"
+`;
+
+exports[`Blueprint snapshots node14 configuration matches src/ServerlessAppRepo/.vscode/tasks.json 1`] = `
+"{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "install",
+            "group": "build",
+            "label": "npm: install",
+            "detail": "npm install",
+            "options": {
+                "cwd": "\${workspaceFolder}/SamFirstEndpoint/hello-world"
+            }
+        },
+        {
+            "type": "npm",
+            "script": "test",
+            "group": "test",
+            "label": "npm: test",
+            "detail": "npm test",
+            "options": {
+                "cwd": "\${workspaceFolder}/SamFirstEndpoint/hello-world"
+            }
+        },
+        {
+            "type": "shell",
+            "command": "sam build",
+            "label": "sam: build",
+            "detail": "sam build",
+            "problemMatcher": []
+        },
+        {
+            "type": "shell",
+            "command": "sam local invoke SamFirstEndpointFunction --event SamFirstEndpoint/events/event.json",
+            "label": "sam: invoke",
+            "detail": "sam invoke",
+            "problemMatcher": []
+        },
+        {
+            "type": "shell",
+            "command": "sam local start-api",
+            "label": "sam: start api",
+            "detail": "sam start api",
+            "isBackground": true,
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "."
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".",
+                    "endsPattern": "Running on"
+                }
+              }
+        }
+    ]
+}
 "
 `;
 

--- a/packages/blueprints/sam-serverless-app/src/runtimeMappings.spec.ts
+++ b/packages/blueprints/sam-serverless-app/src/runtimeMappings.spec.ts
@@ -129,10 +129,46 @@ describe('runtime mappings', () => {
       expect(mapping.templateProps).toBe('');
     });
 
-    it('creates run-tests.sh', () => {
-      expect(mapping.filesToCreate).toHaveLength(1);
+    it('creates eleven files', () => {
+      expect(mapping.filesToCreate).toHaveLength(11);
       expect(mapping.filesToCreate[0].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.codecatalyst/scripts/run-tests.sh');
       expect(mapping.filesToCreate[0].resolveContent(fileTemplateContext)).toContain('WORKING_DIR=testLambdaFunctionName/hello-world/');
+
+      expect(mapping.filesToCreate[1].resolvePath(fileTemplateContext)).toBe(
+        'testRepositoryRelativePath/.idea/runConfigurations/all_tests_coverage.xml',
+      );
+      expect(mapping.filesToCreate[1].resolveContent(fileTemplateContext)).toContain('$PROJECT_DIR$/testLambdaFunctionName/hello-world/package.json');
+      expect(mapping.filesToCreate[2].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.idea/runConfigurations/sam_build.xml');
+      expect(mapping.filesToCreate[2].resolveContent(fileTemplateContext)).toContain('$PROJECT_DIR$');
+      expect(mapping.filesToCreate[3].resolvePath(fileTemplateContext)).toBe(
+        'testRepositoryRelativePath/.idea/runConfigurations/sam_local_invoke.xml',
+      );
+      expect(mapping.filesToCreate[3].resolveContent(fileTemplateContext)).toContain(
+        'sam local invoke testLambdaFunctionNameFunction --event testLambdaFunctionName/events/event.json',
+      );
+      expect(mapping.filesToCreate[4].resolvePath(fileTemplateContext)).toBe(
+        'testRepositoryRelativePath/.idea/runConfigurations/sam_start_local_api.xml',
+      );
+      expect(mapping.filesToCreate[4].resolveContent(fileTemplateContext)).toContain('$PROJECT_DIR$');
+      expect(mapping.filesToCreate[5].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.idea/externalDependencies.xml');
+      expect(mapping.filesToCreate[5].resolveContent(fileTemplateContext)).toContain('aws.toolkit');
+
+      expect(mapping.filesToCreate[6].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.vscode/launch.json');
+      expect(mapping.filesToCreate[6].resolveContent(fileTemplateContext)).toContain('${workspaceFolder}/testLambdaFunctionName');
+
+      expect(mapping.filesToCreate[7].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.vscode/tasks.json');
+      expect(mapping.filesToCreate[7].resolveContent(fileTemplateContext)).toContain('${workspaceFolder}/testLambdaFunctionName');
+
+      expect(mapping.filesToCreate[8].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.vscode/extensions.json');
+      expect(mapping.filesToCreate[8].resolveContent(fileTemplateContext)).toContain('AmazonWebServices.aws-toolkit-vscode');
+
+      expect(mapping.filesToCreate[9].resolvePath(fileTemplateContext)).toBe('testRepositoryRelativePath/.cloud9/runners/SAM Project Builder.run');
+      expect(mapping.filesToCreate[9].resolveContent(fileTemplateContext)).toContain('sam build');
+
+      expect(mapping.filesToCreate[10].resolvePath(fileTemplateContext)).toBe(
+        'testRepositoryRelativePath/.cloud9/runners/SAM Project Test Runner.run',
+      );
+      expect(mapping.filesToCreate[10].resolveContent(fileTemplateContext)).toContain('npm run test');
     });
 
     it('overrides package.json', () => {

--- a/packages/blueprints/sam-serverless-app/src/runtimeMappings.ts
+++ b/packages/blueprints/sam-serverless-app/src/runtimeMappings.ts
@@ -310,6 +310,91 @@ export const runtimeMappings: RuntimeMap = {
           return new SubstitionAsset('nodejs/run-tests.sh').subsitite({ lambdaFunctionName: context.lambdaFunctionName });
         },
       },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.idea', 'runConfigurations', 'all_tests_coverage.xml');
+        },
+        resolveContent(context: FileTemplateContext): string {
+          return new SubstitionAsset('nodejs/.idea/runConfigurations/all_tests_coverage.xml').subsitite({
+            lambdaFunctionName: context.lambdaFunctionName,
+          });
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.idea', 'runConfigurations', 'sam_build.xml');
+        },
+        resolveContent(): string {
+          return new StaticAsset('nodejs/.idea/runConfigurations/sam_build.xml').toString();
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.idea', 'runConfigurations', 'sam_local_invoke.xml');
+        },
+        resolveContent(context: FileTemplateContext): string {
+          return new SubstitionAsset('nodejs/.idea/runConfigurations/sam_local_invoke.xml').subsitite({
+            lambdaFunctionName: context.lambdaFunctionName,
+          });
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.idea', 'runConfigurations', 'sam_start_local_api.xml');
+        },
+        resolveContent(): string {
+          return new StaticAsset('nodejs/.idea/runConfigurations/sam_start_local_api.xml').toString();
+        },
+      },
+
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.idea', 'externalDependencies.xml');
+        },
+        resolveContent(): string {
+          return new StaticAsset('nodejs/.idea/externalDependencies.xml').toString();
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.vscode', 'launch.json');
+        },
+        resolveContent(context: FileTemplateContext): string {
+          return new SubstitionAsset('nodejs/.vscode/launch.json').subsitite({ lambdaFunctionName: context.lambdaFunctionName });
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.vscode', 'tasks.json');
+        },
+        resolveContent(context: FileTemplateContext): string {
+          return new SubstitionAsset('nodejs/.vscode/tasks.json').subsitite({ lambdaFunctionName: context.lambdaFunctionName });
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.vscode', 'extensions.json');
+        },
+        resolveContent(): string {
+          return new StaticAsset('nodejs/.vscode/extensions.json').toString();
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.cloud9', 'runners', 'SAM Project Builder.run');
+        },
+        resolveContent(): string {
+          return new StaticAsset('nodejs/.cloud9/runners/SAM Project Builder.run').toString();
+        },
+      },
+      {
+        resolvePath(context: FileTemplateContext) {
+          return path.join(context.repositoryRelativePath, '.cloud9', 'runners', 'SAM Project Test Runner.run');
+        },
+        resolveContent(): string {
+          return new StaticAsset('nodejs/.cloud9/runners/SAM Project Test Runner.run').toString();
+        },
+      },
     ],
     filesToOverride: [
       {


### PR DESCRIPTION
### Issue
https://issues.amazon.com/issues/AWS-Cloud9-23879

### Description
Enable synthesizing of IDE configurations for Node runtime. 

Node runtime was enabled after IDE configurations were created, so it didn't have any configuration. This change makes sure that configurations are copied to NodeJS repositories as well.

### Testing
- Added unit test
- Synthesized Node project and verified files exist.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
