### PR TITLE
Use universal-image:1.0 instead of latest for the sample devfile.

### DIFF
--- a/packages/blueprints/sam-serverless-app/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
+++ b/packages/blueprints/sam-serverless-app/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
@@ -521,7 +521,7 @@ metadata:
 components:
   - name: aws-runtime
     container:
-      image: public.ecr.aws/aws-mde/universal-image:latest
+      image: public.ecr.aws/aws-mde/universal-image:1.0
       mountSources: true
       volumeMounts:
         - name: docker-store
@@ -2451,7 +2451,7 @@ metadata:
 components:
   - name: aws-runtime
     container:
-      image: public.ecr.aws/aws-mde/universal-image:latest
+      image: public.ecr.aws/aws-mde/universal-image:1.0
       mountSources: true
       volumeMounts:
         - name: docker-store
@@ -3375,7 +3375,7 @@ metadata:
 components:
   - name: aws-runtime
     container:
-      image: public.ecr.aws/aws-mde/universal-image:latest
+      image: public.ecr.aws/aws-mde/universal-image:1.0
       mountSources: true
       volumeMounts:
         - name: docker-store

--- a/packages/components/caws-workspaces/src/samples/index.ts
+++ b/packages/components/caws-workspaces/src/samples/index.ts
@@ -15,7 +15,7 @@ export class SampleWorkspaces {
       {
         name: 'aws-runtime',
         container: {
-          image: 'public.ecr.aws/aws-mde/universal-image:latest',
+          image: 'public.ecr.aws/aws-mde/universal-image:1.0',
           mountSources: true,
           volumeMounts: [
             {


### PR DESCRIPTION
### Issue

Universal Image versioning is evolving. To keep existing blueprints stable they should not rely on `latest` version. `universal-image:1.0` should be used instead. 

### Description

Sample `devfile.yaml` will be based on universal-image:1.0 instead of `universal-image:latest`

### Testing

Manually testing with changing `devfile.yaml` content to rely on `universal-image:1.0`. Then new dev environment were created to check if `universal-image:1.0` is resolved in the same way as `universal-image:latest` 

### Additional context

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
