### PR TITLE
rename label

### DIFF
--- a/packages/blueprints/sam-serverless-app/src/blueprint.ts
+++ b/packages/blueprints/sam-serverless-app/src/blueprint.ts
@@ -62,7 +62,7 @@ export interface Options extends ParentOptions {
   }>;
 
   /**
-   * Select your lambda code language
+   * Select your Lambda development language
    * @displayName Runtime Language
    */
   runtime: 'Node.js 14' | 'Java 11 Gradle' | 'Java 11 Maven' | 'Python 3.9';


### PR DESCRIPTION
### Issue

https://t.corp.amazon.com/V777423130/overview

### Description

label says "Select your lambda code language"

"lambda" should be Capitalized, and this should possibly be reworded, e.g. 

"Select your Lambda development language" 

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
