### PR TITLE
sam-serverless-app (python3.9): use the recommended sam build image, …

### DIFF
--- a/packages/blueprints/sam-serverless-app/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
+++ b/packages/blueprints/sam-serverless-app/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
@@ -2606,7 +2606,8 @@ Actions:
         - Run: . ./.codecatalyst/scripts/run-tests.sh
         - Run: >-
             sam build --template-file template.yaml --use-container
-            --build-image amazon/aws-sam-cli-build-image-python3.9
+            --build-image public.ecr.aws/sam/build-python3.9:$(sam --version |
+            sed "s/.* //")
         - Run: cd .aws-sam/build/
         - Run: >-
             sam package --output-template-file packaged.yaml --resolve-s3
@@ -3394,7 +3395,7 @@ events:
 commands:
   - id: bootstrap-and-build
     exec:
-      commandLine: . ./.codecatalyst/scripts/bootstrap.sh && . ./.codecatalyst/scripts/run-tests.sh && sam build --template-file template.yaml --use-container --build-image amazon/aws-sam-cli-build-image-python3.9
+      commandLine: . ./.codecatalyst/scripts/bootstrap.sh && . ./.codecatalyst/scripts/run-tests.sh && sam build --template-file template.yaml --use-container --build-image public.ecr.aws/sam/build-python3.9:$(sam --version | sed "s/.* //")
       workingDir: $PROJECT_SOURCE
       component: aws-runtime
 "

--- a/packages/blueprints/sam-serverless-app/src/runtimeMappings.ts
+++ b/packages/blueprints/sam-serverless-app/src/runtimeMappings.ts
@@ -597,7 +597,7 @@ export const runtimeMappings: RuntimeMap = {
       },
     ],
     filesToChangePermissionsFor: [],
-    samBuildImage: 'amazon/aws-sam-cli-build-image-python3.9',
+    samBuildImage: 'public.ecr.aws/sam/build-python3.9:$(sam --version | sed "s/.* //")',
     computeOptions: {
       Type: ComputeType.EC2,
       Fleet: ComputeFleet.LINUX_X86_64_LARGE,
@@ -606,7 +606,7 @@ export const runtimeMappings: RuntimeMap = {
       {
         eventName: 'bootstrap-and-build',
         command:
-          '. ./.codecatalyst/scripts/bootstrap.sh && . ./.codecatalyst/scripts/run-tests.sh && sam build --template-file template.yaml --use-container --build-image amazon/aws-sam-cli-build-image-python3.9',
+          '. ./.codecatalyst/scripts/bootstrap.sh && . ./.codecatalyst/scripts/run-tests.sh && sam build --template-file template.yaml --use-container --build-image public.ecr.aws/sam/build-python3.9:$(sam --version | sed "s/.* //")',
       },
       //TODO: uncomment and separate onmi command once dev environments supports multiple postStart events
       // {
@@ -619,7 +619,7 @@ export const runtimeMappings: RuntimeMap = {
       // },
       // {
       //   eventName: 'sam-build',
-      //   command: 'sam build --template-file template.yaml --use-container --build-image amazon/aws-sam-cli-build-image-python3.9',
+      //   command: 'sam build --template-file template.yaml --use-container --build-image public.ecr.aws/sam/build-python3.9:$(sam --version | sed "s/.* //")',
       // },
     ],
   },


### PR DESCRIPTION
…which is arm64 compatible, and pin its version to match that of the build environment's sam-cli installation.

### Description

The image that was previously referenced, ```amazon/aws-sam-cli-build-image-python3.9```, is not available for arm64, which causes instantiations of this blueprint to fail when the build environment is arm64. ```public.ecr.aws/sam/build-python3.9``` is the currently-recommended python3.9 sam build image from https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-image-repositories.html

Furthermore, sam publishes these images with a version corresponding to each sam release, so we can also make sure the image we use matches, avoiding possible confusing failures related to part of the build using sam version A and part of it using sam version B.

### Testing

I synth'ed the blueprint and updated my previously-created-from-codecatalyst project. Workflows pass there. Then I updated the workflow fleet and lambda architectures to Arm64 and verified everything continues to pass.

### Additional context

This is a step towards enabling an architecture toggle on our blueprints. Without this, setting the build environment to arm64 results in sam hanging perpetually due to a long-standing issue (https://github.com/aws/aws-sam-cli/issues/3512) when the image it uses isn't compatible with the build machine.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
