### PR TITLE
fix(blueprints-cli): make blueprints cli executable in node context

### DIFF
--- a/packages/utils/blueprint-cli/src/index.ts
+++ b/packages/utils/blueprint-cli/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import * as fs from 'fs';
 import * as path from 'path';
 import * as pino from 'pino';
@@ -161,71 +162,71 @@ yargs
   //       },
   //     ];
 
-//     if (argv.additionalOptionOverrides) {
-//       fs.readdirSync(argv.additionalOptionOverrides, { withFileTypes: true }).forEach(override => {
-//         runs.push({
-//           optionOverridePath: path.join(argv.additionalOptionOverrides!, override.name),
-//           outputPath: path.resolve(path.join(argv.outdir, 'synth', `00.resynth.${override.name}`)),
-//         });
-//       });
-//     }
+  //     if (argv.additionalOptionOverrides) {
+  //       fs.readdirSync(argv.additionalOptionOverrides, { withFileTypes: true }).forEach(override => {
+  //         runs.push({
+  //           optionOverridePath: path.join(argv.additionalOptionOverrides!, override.name),
+  //           outputPath: path.resolve(path.join(argv.outdir, 'synth', `00.resynth.${override.name}`)),
+  //         });
+  //       });
+  //     }
 
-//     await resynthesize(log, {
-//       blueprintPath: argv.blueprint,
-//       defaultsPath: argv.options || '',
-//       useCache: argv.cache,
-//       runs,
-//     });
-//     process.exit(0);
-//   },
-// })
-//resynth driver command
-// .command({
-//   command: 'resynth <blueprint>',
-//   describe: 'locally resynthesize the blueprint, using the defaults.json any wizard configs (if they exist)',
-//   builder: (args: yargs.Argv<unknown>) => {
-//     return args
-//       .positional('blueprint', {
-//         describe: 'path to the blueprint package directory',
-//         type: 'string',
-//         demandOption: true,
-//       })
-//       .option('outdir', {
-//         describe: 'output directory for blueprint resynthesis',
-//         type: 'string',
-//         demandOption: true,
-//       })
-//       .option('options', {
-//         description: 'path to defaults.json to feed default values into synthesis',
-//         type: 'string',
-//         demandOption: true,
-//       })
-//       .option('cache', {
-//         description: 'Generate and synth from a webpacked cache',
-//         default: false,
-//         type: 'boolean',
-//       })
-//       .option('additionalOverrides', {
-//         description: 'synthesize additional partial options over the default to a stable directory',
-//         type: 'string',
-//       });
-//   },
-//   handler: async (argv: ResynthesizeCliOptions): Promise<void> => {
-//     const runs: SynthRun[] = [
-//       {
-//         optionOverridePath: argv.options,
-//         outputPath: path.join(argv.outdir, 'synth', `00.resynth.${path.parse(argv.options).base}`),
-//       },
-//     ];
+  //     await resynthesize(log, {
+  //       blueprintPath: argv.blueprint,
+  //       defaultsPath: argv.options || '',
+  //       useCache: argv.cache,
+  //       runs,
+  //     });
+  //     process.exit(0);
+  //   },
+  // })
+  //resynth driver command
+  // .command({
+  //   command: 'resynth <blueprint>',
+  //   describe: 'locally resynthesize the blueprint, using the defaults.json any wizard configs (if they exist)',
+  //   builder: (args: yargs.Argv<unknown>) => {
+  //     return args
+  //       .positional('blueprint', {
+  //         describe: 'path to the blueprint package directory',
+  //         type: 'string',
+  //         demandOption: true,
+  //       })
+  //       .option('outdir', {
+  //         describe: 'output directory for blueprint resynthesis',
+  //         type: 'string',
+  //         demandOption: true,
+  //       })
+  //       .option('options', {
+  //         description: 'path to defaults.json to feed default values into synthesis',
+  //         type: 'string',
+  //         demandOption: true,
+  //       })
+  //       .option('cache', {
+  //         description: 'Generate and synth from a webpacked cache',
+  //         default: false,
+  //         type: 'boolean',
+  //       })
+  //       .option('additionalOverrides', {
+  //         description: 'synthesize additional partial options over the default to a stable directory',
+  //         type: 'string',
+  //       });
+  //   },
+  //   handler: async (argv: ResynthesizeCliOptions): Promise<void> => {
+  //     const runs: SynthRun[] = [
+  //       {
+  //         optionOverridePath: argv.options,
+  //         outputPath: path.join(argv.outdir, 'synth', `00.resynth.${path.parse(argv.options).base}`),
+  //       },
+  //     ];
 
-//     if (argv.additionalOptionOverrides) {
-//       fs.readdirSync(argv.additionalOptionOverrides, { withFileTypes: true }).forEach(override => {
-//         runs.push({
-//           optionOverridePath: path.join(argv.additionalOptionOverrides!, override.name),
-//           outputPath: path.resolve(path.join(argv.outdir, 'synth', `00.resynth.${override.name}`)),
-//         });
-//       });
-//     }
+  //     if (argv.additionalOptionOverrides) {
+  //       fs.readdirSync(argv.additionalOptionOverrides, { withFileTypes: true }).forEach(override => {
+  //         runs.push({
+  //           optionOverridePath: path.join(argv.additionalOptionOverrides!, override.name),
+  //           outputPath: path.resolve(path.join(argv.outdir, 'synth', `00.resynth.${override.name}`)),
+  //         });
+  //       });
+  //     }
 
   //     await resynthesize(log, {
   //       blueprintPath: argv.blueprint,

--- a/packages/utils/blueprint-cli/src/synth-drivers/synth-driver.ts
+++ b/packages/utils/blueprint-cli/src/synth-drivers/synth-driver.ts
@@ -87,6 +87,11 @@ export function driveSynthesis(log: pino.BaseLogger, options: SynthDriverCliOpti
       const outputDir = path.join(options.outdir, `${jobname}`);
       log.info('==========================================');
       log.info(`[${jobname}]`);
+      log.info(
+        `npx blueprint synth --options merge[${options.defaultOptions},${wizardOption.path}] --blueprint ${options.blueprint} --outdir ${outputDir} ${
+          (options.cache && '--cache') || ''
+        }`,
+      );
       log.info('==========================================');
       synthesize(log, {
         blueprintPath: options.blueprint,


### PR DESCRIPTION
fix(blueprints-cli): make blueprints cli executable in node context by default

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
