### PR TITLE
feat(blueprint): Add Region type

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -12,6 +12,41 @@ export interface ParentOptions {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Options extends ParentOptions {}
 
+export type AWS_REGIONS =
+  | 'af-south-1'
+  | 'ap-east-1'
+  | 'ap-northeast-1'
+  | 'ap-northeast-2'
+  | 'ap-northeast-3'
+  | 'ap-south-1'
+  | 'ap-south-2'
+  | 'ap-southeast-1'
+  | 'ap-southeast-2'
+  | 'ap-southeast-3'
+  | 'ap-southeast-4'
+  | 'ca-central-1'
+  | 'cn-north-1'
+  | 'cn-northwest-1'
+  | 'eu-central-1'
+  | 'eu-central-2'
+  | 'eu-north-1'
+  | 'eu-south-1'
+  | 'eu-south-2'
+  | 'eu-west-1'
+  | 'eu-west-2'
+  | 'eu-west-3'
+  | 'il-central-1'
+  | 'me-central-1'
+  | 'me-south-1'
+  | 'sa-east-1'
+  | 'us-east-1'
+  | 'us-east-2'
+  | 'us-west-1'
+  | 'us-west-2';
+
+//@ts-ignore
+export type Region<T extends AWS_REGIONS[]> = string;
+
 export class Blueprint extends Project {
   public readonly context: Context;
 


### PR DESCRIPTION
### Description

Add Region type to base blueprint, allowing authors to specify which regions can be selected by users in the wizard.

The frontend code is not yet in production, wait to merge.


### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
