### PR TITLE
feat(blueprint): Add Region type

### DIFF
--- a/packages/blueprints/blueprint/src/index.ts
+++ b/packages/blueprints/blueprint/src/index.ts
@@ -1,6 +1,6 @@
 export * from './blueprint';
 export * from './context';
-export * from './regions';
+export * from './region';
 
 import defaults_ from './defaults.json';
 export const defaults = defaults_;

--- a/packages/blueprints/blueprint/src/region.ts
+++ b/packages/blueprints/blueprint/src/region.ts
@@ -30,5 +30,4 @@ export type AWS_REGIONS =
   | 'us-west-2'
   | '*';
 
-//@ts-ignore
-export type Region<T extends AWS_REGIONS[]> = string;
+export type Region<T extends AWS_REGIONS[]> = T | string;


### PR DESCRIPTION
### Description

Add Region type to base blueprint, allowing authors to specify which regions can be selected by users in the wizard.

Design doc: https://quip-amazon.com/9dzmAbDa7nr6/Design-Blueprint-Interface-Region-Selector


### Testing

How was this change tested?

I copied the new types to my own blueprint and tested it locally with various Region configurations.

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
