### PR TITLE
chore: add secret scanning to precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged",
+      "pre-commit": "pretty-quick --staged && trufflehog git file://. --fail --only-verified",
       "pre-push": "yarn build"
     }
   },


### PR DESCRIPTION
### Description

Add secret scanning step to pre-commit hook using [trufflehog](https://github.com/trufflesecurity/trufflehog), as part of open-sourcing AppSec requirements.

### Testing

`yarn && yarn build`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
