### PR TITLE
fix(blueprint): use correct fallback strategy in resynth output

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -8,7 +8,7 @@ import { TraversalOptions, traverse } from './context/traverse';
 import { createContextFile, destructurePath } from './resynthesis/context-file';
 import { filepathSet } from './resynthesis/file-set';
 import { StrategyLocations, deserializeStrategies } from './resynthesis/merge-strategies/deserialize-strategies';
-import { match } from './resynthesis/merge-strategies/match';
+import { FALLBACK_STRATEGY_ID, match } from './resynthesis/merge-strategies/match';
 import { Strategy } from './resynthesis/merge-strategies/models';
 
 export interface ParentOptions {
@@ -76,14 +76,14 @@ export class Blueprint extends Project {
     const validStrategies: StrategyLocations = deserializeStrategies(existingBundle, this.strategies || {});
     // used for pretty formatting
     let maxIdlength = 0;
-    console.log('<<STRATEGY>> [SYS-FALLBACK] [FALLBACK_never_update] matches [*]');
+    console.log(`<<STRATEGY>> [SYS-FALLBACK] [${FALLBACK_STRATEGY_ID}] matches [*]`);
     for (const [ownershipFile, strategies] of Object.entries(validStrategies)) {
       for (const strategy of strategies) {
         console.log(`<<STRATEGY>> [${ownershipFile}] [${strategy.identifier}] matches [${strategy.globs}]`);
         maxIdlength = Math.max(strategy.identifier.length, maxIdlength);
       }
     }
-    maxIdlength = Math.max(maxIdlength, 'STRATEGY-SYS-FALLBACK'.length);
+    maxIdlength = Math.max(maxIdlength, FALLBACK_STRATEGY_ID.length);
 
     //2. construct the superset of files between [ancestorBundle, existingBundle, proposedBundle]/src
     // only consider files under the source code 'src'
@@ -147,7 +147,5 @@ export class BlueprintSynthesisError extends Error {
 }
 
 function structureMatchReport(maxStrategyLength: number, strategy: Strategy, repository: string, filepath: string) {
-  return `[${strategy.identifier}] ${' '.repeat(maxStrategyLength - strategy.identifier.length)} [${repository}] [${filepath}] -> [${
-    strategy.globs
-  }]`;
+  return `[${strategy.identifier}]${' '.repeat(maxStrategyLength - strategy.identifier.length)} [${repository}] [${filepath}] -> [${strategy.globs}]`;
 }

--- a/packages/blueprints/blueprint/src/resynthesis/merge-strategies/match.ts
+++ b/packages/blueprints/blueprint/src/resynthesis/merge-strategies/match.ts
@@ -3,6 +3,9 @@ import { Strategy } from './models';
 import { Ownership } from '../ownership';
 import { matchesGlob } from '../walk-files';
 
+export const FALLBACK_STRATEGY = MergeStrategies.threeWayMerge;
+export const FALLBACK_STRATEGY_ID = `FALLBACK_${FALLBACK_STRATEGY.name}`;
+
 export function match(bundlePath: string, strategies: { [bundlepath: string]: Strategy[] }): Strategy {
   const directories = bundlePath.split('/');
 
@@ -24,8 +27,8 @@ export function match(bundlePath: string, strategies: { [bundlepath: string]: St
   }
 
   return {
-    identifier: 'FALLBACK_three_way_merge',
-    strategy: MergeStrategies.threeWayMerge,
+    identifier: FALLBACK_STRATEGY_ID,
+    strategy: FALLBACK_STRATEGY,
     globs: ['*'],
   };
 }


### PR DESCRIPTION
We previously updated the default merge strategy to be three way merge, but didn't update the debug logging in the resynth command to reflect this.

### Issue

Issue number, if available, prefixed with "#"

### Description

Updates the strategy ID logged by resynth.

### Testing

`yarn build` and tested a resynth of sam-serverless

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
