### PR TITLE
feat(blueprint): Add wildcard ownership matching

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -7,7 +7,7 @@ import { Context } from './context/context';
 import { TraversalOptions, traverse } from './context/traverse';
 import { createContextFile, destructurePath } from './resynthesis/context-file';
 import { filepathSet } from './resynthesis/file-set';
-import { StrategyLocations, deserializeStrategies, merge } from './resynthesis/merge-strategies/deserialize-strategies';
+import { StrategyLocations, deserializeStrategies, filterStrategies, merge } from './resynthesis/merge-strategies/deserialize-strategies';
 import { FALLBACK_STRATEGY_ID, match } from './resynthesis/merge-strategies/match';
 import { Strategy } from './resynthesis/merge-strategies/models';
 import { Ownership } from './resynthesis/ownership';
@@ -76,7 +76,7 @@ export class Blueprint extends Project {
   resynth(ancestorBundle: string, existingBundle: string, proposedBundle: string) {
     //1. find the merge strategies from the exisiting codebase, deserialize and match against strategies in memory
     const overriddenStrategies: StrategyLocations = deserializeStrategies(existingBundle, this.strategies || {});
-    const validStrategies = merge(this.strategies || {}, overriddenStrategies);
+    const validStrategies = merge(this.strategies || {}, filterStrategies(overriddenStrategies, this.context.package));
 
     // used for pretty formatting
     let maxIdlength = 0;

--- a/packages/blueprints/blueprint/src/resynthesis/merge-strategies/deserialize-strategies.spec.ts
+++ b/packages/blueprints/blueprint/src/resynthesis/merge-strategies/deserialize-strategies.spec.ts
@@ -1,0 +1,54 @@
+import { filterStrategies } from './deserialize-strategies';
+import { MergeStrategies } from './merge-strategies';
+import { Strategy } from './models';
+
+describe('filterStrategies', () => {
+  it('filters strategies with non-matching owners', () => {
+    const baseStrategy: Strategy = {
+      identifier: 'my_strategy',
+      strategy: MergeStrategies.alwaysUpdate,
+      globs: ['*'],
+    };
+
+    const matchingStrategies = [
+      '*',
+      '@caws-blueprints/*',
+      '@caws-blueprints/test-blueprint',
+      '@caws-blueprints/test-blueprint@1.2.3',
+      '@caws-blueprints/test-blueprint@1.*.*',
+      '*/test-blueprint',
+      '*/*@1.*',
+    ].map(owner => {
+      return {
+        ...baseStrategy,
+        owner,
+      };
+    });
+
+    const nonmatchingStrategies = [
+      '@another-namespace/test-blueprint',
+      '@another-namespace/*',
+      '@caws-blueprints/test-blueprint@2.0.0',
+      '*/wrong-name',
+    ].map(owner => {
+      return {
+        ...baseStrategy,
+        owner,
+      };
+    });
+
+    const filtered = filterStrategies(
+      {
+        'src/repo/.blueprint-ownership': [...matchingStrategies, ...nonmatchingStrategies],
+      },
+      {
+        name: '@caws-blueprints/test-blueprint',
+        version: '1.2.3',
+      },
+    );
+
+    expect(filtered).toStrictEqual({
+      'src/repo/.blueprint-ownership': matchingStrategies,
+    });
+  });
+});


### PR DESCRIPTION
Implements simple wildcard matching (only supporting '*') for owners specified in an override file. During resynth, strategies that do not match the current package name/version are filtered from the list of valid strategies.

### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
