### PR TITLE
chore: add semgrep static analysis scan action

### DIFF
--- a/.github/workflows/static-analysis-scan.yml
+++ b/.github/workflows/static-analysis-scan.yml
@@ -1,0 +1,25 @@
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+name: Semgrep Scan
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: |
+          semgrep scan \
+            --error \
+            --metrics=off \
+            --config="p/typescript"


### PR DESCRIPTION
### Description

Adding an action to the release workflow for static analysis security scan using the third-party tool semgrep, as per AppSec recommendations for open-sourcing.

### Testing

How was this change tested?

`yarn && yarn build`

Tested that the action fails upon finding warnings or errors in typescript code and succeeds otherwise in a test repository.

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
