### PR TITLE
fix: write difference and PR components during synthesis

### DIFF
--- a/packages/components/caws-source-repositories/src/pull-request/pull-request.ts
+++ b/packages/components/caws-source-repositories/src/pull-request/pull-request.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { Blueprint } from '@caws-blueprint/blueprints.blueprint';
 import { BUNDLE_PATH_PULL_REQUEST, writePullRequest } from '@caws-blueprint/blueprints.blueprint/lib/pull-requests/pull-requests';
+import { Component } from 'projen';
 import { Difference } from '../difference/difference';
 
 
@@ -21,15 +22,19 @@ export interface PullRequestDefinition {
   changes?: Difference[];
 }
 
-export class PullRequest {
+export class PullRequest extends Component {
 
   public static BUNDLE_PATH = BUNDLE_PATH_PULL_REQUEST;
 
-  constructor(protected readonly blueprint_: Blueprint, identifier: string, options: PullRequestDefinition) {
-    writePullRequest(this.blueprint_.outdir, identifier, {
-      title: options.title,
-      description: options.description,
-      changes: (options.changes || []).map(diff => {
+  constructor(readonly blueprint: Blueprint, readonly identifier: string, readonly options: PullRequestDefinition) {
+    super(blueprint);
+  }
+
+  synthesize(): void {
+    writePullRequest(this.blueprint.outdir, this.identifier, {
+      title: this.options.title,
+      description: this.options.description,
+      changes: (this.options.changes || []).map(diff => {
         return {
           diffs: path.join(Difference.BUNDLE_PATH, diff.identifier),
           repository: diff.repository.title,


### PR DESCRIPTION
### Issue

We mistakenly wrote diff and PR components in the constructor. We need to write them during synthesis to keep phases aligned. Otherwise we write these mistakenly during resynth (for example)

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
