### PR TITLE
fix(serverless-tinyurl): Escape backslashes in diff

### DIFF
--- a/packages/blueprints/serverless-tinyurl/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
+++ b/packages/blueprints/serverless-tinyurl/src/__snapshots__/blueprint-snapshot-driver.spec.ts.snap
@@ -2474,7 +2474,7 @@ index 08263b89..00000000
 -  roots: ['<rootDir>/test'],
 -  testMatch: ['**/*.test.ts'],
 -  transform: {
--    '^.+\\.tsx?$': 'ts-jest'
+-    '^.+\\\\.tsx?$': 'ts-jest'
 -  }
 -};
 "

--- a/packages/blueprints/serverless-tinyurl/src/blueprint.ts
+++ b/packages/blueprints/serverless-tinyurl/src/blueprint.ts
@@ -140,7 +140,7 @@ index 08263b89..00000000
 -  roots: ['<rootDir>/test'],
 -  testMatch: ['**/*.test.ts'],
 -  transform: {
--    '^.+\\.tsx?$': 'ts-jest'
+-    '^.+\\\\.tsx?$': 'ts-jest'
 -  }
 -};\n`,
     );


### PR DESCRIPTION
### Description

The back slashes in the patch were being escaped.

### Testing

applied the patch to the generated source code, which succeeded.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
