### PR TITLE
fix(blueprints-cli): pass anti-csrf token as part of cookie auth

### DIFF
--- a/packages/utils/blueprint-cli/src/publish/publish.ts
+++ b/packages/utils/blueprint-cli/src/publish/publish.ts
@@ -4,7 +4,7 @@ import * as pino from 'pino';
 import * as yargs from 'yargs';
 import { codecatalystAuthentication } from './codecatalyst-authentication';
 import { uploadBlueprint } from './upload-blueprint';
-import { verifyIdentity } from './verify-identity';
+import { IdentityResponse, verifyIdentity } from './verify-identity';
 
 export interface PublishOptions extends yargs.Arguments {
   blueprint: string;
@@ -38,7 +38,7 @@ export async function publish(log: pino.BaseLogger, endpoint: string, options: {
     region: options.region,
   });
 
-  let identity;
+  let identity: IdentityResponse;
   if (authentication) {
     log.info('Verifying identity...');
     identity = await verifyIdentity(endpoint, { authentication });
@@ -81,5 +81,6 @@ export async function publish(log: pino.BaseLogger, endpoint: string, options: {
     packageName,
     version,
     authentication,
+    identity,
   });
 }

--- a/packages/utils/blueprint-cli/src/publish/upload-blueprint.ts
+++ b/packages/utils/blueprint-cli/src/publish/upload-blueprint.ts
@@ -5,6 +5,7 @@ import * as util from 'util';
 import * as axios from 'axios';
 import * as pino from 'pino';
 import { CodeCatalystAuthentication, generateHeaders } from './codecatalyst-authentication';
+import { IdentityResponse } from './verify-identity';
 
 const mb = 1_024_000;
 
@@ -19,6 +20,7 @@ export async function uploadBlueprint(log: pino.BaseLogger, packagePath: string,
   packageName: string;
   version: string;
   authentication: CodeCatalystAuthentication;
+  identity: IdentityResponse;
 }) {
 
   // get the signature of the package
@@ -52,7 +54,7 @@ export async function uploadBlueprint(log: pino.BaseLogger, packagePath: string,
         'origin': `https://${endpoint}`,
         'accept': 'application/json',
         'content-type': 'application/json',
-        ...generateHeaders(blueprint.authentication),
+        ...generateHeaders(blueprint.authentication, blueprint.identity),
       },
     },
   );

--- a/packages/utils/blueprint-cli/src/publish/verify-identity.ts
+++ b/packages/utils/blueprint-cli/src/publish/verify-identity.ts
@@ -1,7 +1,7 @@
 import * as axios from 'axios';
 import { CodeCatalystAuthentication, generateHeaders } from './codecatalyst-authentication';
 
-interface IdentityResponse {
+export interface IdentityResponse {
   name: string;
   email: string;
   csrfToken?: string;


### PR DESCRIPTION
### Issue

Cookie auth method was not properly passing csrf token

### Description

Fix now passes a csrf token when using cookie auth

### Testing

- [x] Test publishing with a cookie
- [x] unset cookie
- [x] Test publishing with SSO

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
