### PR TITLE
feat(blueprint-cli): enable stream blueprint upload and status queries 

### DIFF
--- a/packages/utils/blueprint-cli/src/publish/upload-blueprint.ts
+++ b/packages/utils/blueprint-cli/src/publish/upload-blueprint.ts
@@ -35,6 +35,7 @@ export async function uploadBlueprint(
 
   log.info(`Starting publishing blueprint package to ${blueprint.targetSpace}.`);
   log.info(`Generating a readstream to ${packagePath}`);
+
   const blueprintTarballStream = fs.createReadStream(packagePath);
   const publishBlueprintPackageResponse = await axios.default({
     method: 'PUT',
@@ -44,6 +45,7 @@ export async function uploadBlueprint(
       'authority': endpoint,
       'origin': `https://${endpoint}`,
       'Content-Type': 'application/octet-stream',
+      'Content-Length': fs.statSync(packagePath).size,
       ...generateHeaders(blueprint.authentication, blueprint.identity),
     },
   });


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

## NOTE: 

Blueprint uploading at 
```
https://${endpoint}/v1/spaces/${querystring.escape(blueprint.targetSpace)}/blueprints/${querystring.escape(blueprint.packageName)}/versions/${querystring.escape(blueprint.version)}/packages
```
does not error. However status requests at 
```
query GetBlueprintVersionStatus
```
error with validation problems. This needs to be solved server side


### Testing

```
npx blueprint publish ./ --publisher blueprints --endpoint public.api-gamma.quokka.codes
```


### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
