### PR TITLE
 fix: npm valid packages by default. Add helpful check in cli

### DIFF
--- a/packages/blueprints/blueprint-builder/src/blueprint.ts
+++ b/packages/blueprints/blueprint-builder/src/blueprint.ts
@@ -85,8 +85,8 @@ export class Blueprint extends ParentBlueprint {
       },
     ]);
 
-    const spaceName = this.context.spaceName || '<<unknown-organization>>';
-    const packageName = `@amazon-codecatalyst/${spaceName}.${dashName}`;
+    const spaceName = this.context.spaceName || '<<unknown-space>>';
+    const packageName = `@amazon-codecatalyst/${spaceName}.${dashName}`.substring(0, 214).toLocaleLowerCase().replace(/[_ ]/g, '-');
 
     const newBlueprintOptions: ProjenBlueprintOptions = {
       authorName: options.authorName,

--- a/packages/utils/blueprint-cli/src/publish/publish.ts
+++ b/packages/utils/blueprint-cli/src/publish/publish.ts
@@ -55,6 +55,13 @@ export async function publish(
 
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
   const packageName: string = packageJson.name;
+  if (!packageName.match(/^(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)?\/)?[a-z0-9-~][a-z0-9-._~]*$/) || packageName.length > 214) {
+    log.error(
+      `Package ['${packageName}'] not match NPM regex \`^(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)?\/)?[a-z0-9-~][a-z0-9-._~]*$\` or is not less than 214 characters.`,
+    );
+    process.exit(255);
+  }
+
   const version = packageJson.version;
 
   const distributionFolder = path.join(options.blueprintPath, 'dist', 'js');


### PR DESCRIPTION
### Issue

In some cases customers might generate a new blueprint that doesn't adhere to NPM package specifications by default. 
- [x] Fix this in the blueprint builder
- [x] Add pre-publish helpful validation in the publishing CLI

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
