### PR TITLE
fix: update versioning strategy to support monorepo

### DIFF
--- a/packages/utils/projen-blueprint/src/blueprint.ts
+++ b/packages/utils/projen-blueprint/src/blueprint.ts
@@ -102,7 +102,7 @@ export class ProjenBlueprint extends typescript.TypeScriptProject {
     };
     super(finalOpts);
 
-    const version = options.overridePackageVersion || JSON.parse(fs.readFileSync(path.resolve('./package.json'), 'utf-8')).version;
+    const version = options.overridePackageVersion || JSON.parse(fs.readFileSync(path.resolve(this.outdir, 'package.json'), 'utf-8')).version;
     this.package.addVersion(version || '0.0.0');
     this.addDevDeps('ts-node@^10');
 


### PR DESCRIPTION
Fixes: #424

### Issue

#424

### Description

Update the versioning preservation code to account for non-root projects and be explicit about which bumpfile to use.

### Testing

Tested in a monorepo and standalone project.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
