### PR TITLE
fix: pin aws sdk to v3.414.0, bearer token auth

### DIFF
--- a/packages/blueprints/blueprint-builder/.projen/deps.json
+++ b/packages/blueprints/blueprint-builder/.projen/deps.json
@@ -57,6 +57,11 @@
       "type": "build"
     },
     {
+      "name": "@aws-sdk/client-codecatalyst",
+      "version": "3.414.0",
+      "type": "override"
+    },
+    {
       "name": "projen",
       "version": "0.71.112",
       "type": "override"

--- a/packages/blueprints/blueprint-builder/package.json
+++ b/packages/blueprints/blueprint-builder/package.json
@@ -61,6 +61,7 @@
     "typescript": "4.x"
   },
   "resolutions": {
+    "@aws-sdk/client-codecatalyst": "3.414.0",
     "projen": "0.71.112"
   },
   "keywords": [

--- a/packages/blueprints/blueprint/.projen/deps.json
+++ b/packages/blueprints/blueprint/.projen/deps.json
@@ -87,6 +87,11 @@
       "type": "build"
     },
     {
+      "name": "@aws-sdk/client-codecatalyst",
+      "version": "3.414.0",
+      "type": "override"
+    },
+    {
       "name": "projen",
       "version": "0.71.112",
       "type": "override"

--- a/packages/blueprints/blueprint/package.json
+++ b/packages/blueprints/blueprint/package.json
@@ -66,6 +66,7 @@
     "yaml": "*"
   },
   "resolutions": {
+    "@aws-sdk/client-codecatalyst": "3.414.0",
     "projen": "0.71.112"
   },
   "keywords": [

--- a/packages/blueprints/sam-serverless-app/.projen/deps.json
+++ b/packages/blueprints/sam-serverless-app/.projen/deps.json
@@ -96,6 +96,11 @@
       "type": "build"
     },
     {
+      "name": "@aws-sdk/client-codecatalyst",
+      "version": "3.414.0",
+      "type": "override"
+    },
+    {
       "name": "projen",
       "version": "0.71.112",
       "type": "override"

--- a/packages/blueprints/sam-serverless-app/package.json
+++ b/packages/blueprints/sam-serverless-app/package.json
@@ -73,6 +73,7 @@
     "ts-deepmerge": "*"
   },
   "resolutions": {
+    "@aws-sdk/client-codecatalyst": "3.414.0",
     "projen": "0.71.112"
   },
   "keywords": [

--- a/packages/blueprints/test-blueprint/.projen/deps.json
+++ b/packages/blueprints/test-blueprint/.projen/deps.json
@@ -65,6 +65,11 @@
       "type": "build"
     },
     {
+      "name": "@aws-sdk/client-codecatalyst",
+      "version": "3.414.0",
+      "type": "override"
+    },
+    {
       "name": "projen",
       "version": "0.71.112",
       "type": "override"

--- a/packages/blueprints/test-blueprint/package.json
+++ b/packages/blueprints/test-blueprint/package.json
@@ -57,6 +57,7 @@
     "projen": "0.71.112"
   },
   "resolutions": {
+    "@aws-sdk/client-codecatalyst": "3.414.0",
     "projen": "0.71.112"
   },
   "keywords": [

--- a/packages/utils/blueprint-cli/.projen/deps.json
+++ b/packages/utils/blueprint-cli/.projen/deps.json
@@ -106,6 +106,7 @@
     },
     {
       "name": "@aws-sdk/client-codecatalyst",
+      "version": "3.414.0",
       "type": "runtime"
     },
     {

--- a/packages/utils/blueprint-cli/.projen/tasks.json
+++ b/packages/utils/blueprint-cli/.projen/tasks.json
@@ -207,19 +207,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-sdk/client-codecatalyst,projen'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-sdk/client-codecatalyst,projen'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-sdk/client-codecatalyst,projen'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-sdk/client-codecatalyst,projen'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='projen'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-sdk/client-codecatalyst,projen'"
         },
         {
           "exec": "yarn install --check-files"

--- a/packages/utils/blueprint-cli/.projenrc.ts
+++ b/packages/utils/blueprint-cli/.projenrc.ts
@@ -19,6 +19,10 @@ const project = new ProjenBlueprintComponent({
     'typescript',
     'jmespath',
     'deepmerge',
+    /**
+     * We depend the sdk to provide bearer token auth for publishing, we cannot have it change.
+     */
+    '@aws-sdk/client-codecatalyst@3.414.0',
   ],
   peerDeps: [],
   description: 'This is a cli utility used for blueprint development.',

--- a/packages/utils/blueprint-cli/package.json
+++ b/packages/utils/blueprint-cli/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3.360.0",
-    "@aws-sdk/client-codecatalyst": "^3.395.0",
+    "@aws-sdk/client-codecatalyst": "3.414.0",
     "@aws-sdk/client-s3": "^3.360.0",
     "@aws-sdk/client-sts": "^3.360.0",
     "ajv": "^8.12.0",

--- a/packages/utils/projen-blueprint/src/blueprint.ts
+++ b/packages/utils/projen-blueprint/src/blueprint.ts
@@ -122,6 +122,12 @@ export class ProjenBlueprint extends typescript.TypeScriptProject {
     this.package.addDeps(`projen@${projenVersion}`);
     this.package.addPackageResolutions(`projen@${projenVersion}`);
 
+    /**
+     * Force blueprints into using @aws-sdk/client-codecatalyst v3.414.0.
+     * We depend the sdk to provide bearer token auth, we cannot have it change.
+     */
+    this.package.addPackageResolutions('@aws-sdk/client-codecatalyst@3.414.0');
+
     // modify bumping tasks
     this.removeTask('release');
     this.removeTask('bump');

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,7 +131,7 @@ __metadata:
   dependencies:
     "@amazon-codecatalyst/blueprint-util.projen-blueprint-component": "*"
     "@aws-sdk/client-cloudfront": ^3.360.0
-    "@aws-sdk/client-codecatalyst": ^3.395.0
+    "@aws-sdk/client-codecatalyst": 3.414.0
     "@aws-sdk/client-s3": ^3.360.0
     "@aws-sdk/client-sts": ^3.360.0
     "@types/jest": 26.0.24
@@ -512,7 +512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-codecatalyst@npm:^3.395.0":
+"@aws-sdk/client-codecatalyst@npm:3.414.0":
   version: 3.414.0
   resolution: "@aws-sdk/client-codecatalyst@npm:3.414.0"
   dependencies:


### PR DESCRIPTION
### Issue

The AWS SDK switched auth methods. We use middleware to grab auth tokens off the aws sdk verify session call

### Description

Pin the version of the SDK. Force SDK version resolutions from the blueprint

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
