### PR TITLE
fix: throw a warning when a string field doesnt have a @validationRegex

### DIFF
--- a/packages/utils/blueprint-cli/src/validate-options.spec.ts
+++ b/packages/utils/blueprint-cli/src/validate-options.spec.ts
@@ -52,7 +52,7 @@ describe('Verifies that properties on an AST pass the @validation regex', () => 
   });
 
   describe('Example blueprint frontend-showcase', () => {
-    it('should have one warning message and one error message', () => {
+    it('should have one warning message and one warning message', () => {
       const errors = validateOptions(JSON.stringify(astShowcase), astShowcaseDefaults);
 
       // should have one warning about could not find element
@@ -64,7 +64,7 @@ describe('Verifies that properties on an AST pass the @validation regex', () => 
       expect(errors[0].validationMessage).toBe('Could not find an element at nestedArea.emptyInput');
 
       // there's no validation message on a string array
-      expect(errors[1].level).toBe('ERROR');
+      expect(errors[1].level).toBe('WARNING');
       expect(errors[1].location).toBe('stringListInput[*]');
       expect(errors[1].validationMessage?.length).toBeGreaterThan(1);
     });

--- a/packages/utils/blueprint-cli/src/validate-options.ts
+++ b/packages/utils/blueprint-cli/src/validate-options.ts
@@ -79,7 +79,7 @@ function validateNode(node: Node, values: string[], regex: string): ValiationErr
     return [
       {
         ...error,
-        level: 'ERROR',
+        level: 'WARNING',
         value: JSON.stringify(values),
         validationMessage,
       },


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
