### PR TITLE
fix(workflow-component): add generic action better action name handling

### DIFF
--- a/packages/components/workflows/src/workflow/workflow-builder.ts
+++ b/packages/components/workflows/src/workflow/workflow-builder.ts
@@ -126,7 +126,9 @@ export class WorkflowBuilder {
     },
   >(configuration: T & any): WorkflowBuilder {
     this.definition.Actions = this.definition.Actions || {};
-    this.definition.Actions[configuration.actionName] = configuration;
+    const actionName = configuration.actionName;
+    delete configuration.actionName;
+    this.definition.Actions[actionName] = configuration;
     return this;
   }
 }


### PR DESCRIPTION
The add generic action mention preserved an `actionName` which resulted in an invalid config most of the time. Fixed 


### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
