### PR TITLE
fix(source-repositories): Fix file name mangling in copyStaticFiles

### DIFF
--- a/packages/components/source-repositories/src/repository.spec.ts
+++ b/packages/components/source-repositories/src/repository.spec.ts
@@ -1,0 +1,100 @@
+import { Blueprint } from '@amazon-codecatalyst/blueprints.blueprint';
+import { SourceFile } from './files/source-file';
+import { SourceRepository } from './repository';
+import { SubstitionAsset } from './static-assets';
+
+jest.mock('./files/source-file');
+
+jest.mock('./static-assets', () => ({
+  SubstitionAsset: {
+    findAll: jest.fn().mockImplementation(() => {
+      return [];
+    }),
+  },
+}));
+
+const mockSubstitutionAsset = jest.mocked(SubstitionAsset);
+const mockSourceFile = jest.mocked(SourceFile);
+
+const mockBlueprint = {
+  context: {
+    rootDir: '.',
+  },
+  _addComponent: jest.fn(),
+} as unknown as Blueprint;
+
+describe('SourceRepository', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('copyStaticFiles', () => {
+    it('preserves file names', () => {
+      const testAssets = ['.dotfile', 'test.ts', 'test-file', 'src/.dotfile', 'src/test.ts', 'src/test-file'];
+      mockStaticAssets(...testAssets);
+
+      const repo = new SourceRepository(mockBlueprint, {
+        title: 'test-repo',
+      });
+
+      repo.copyStaticFiles();
+
+      testAssets.forEach(path => {
+        expect(mockSourceFile).toHaveBeenCalledWith(repo, path, TEST_FILE_CONTENTS);
+      });
+    });
+
+    it('copies static files from a directory to a different directory', () => {
+      const testAssets = ['src/.dotfile', 'src/test.ts', 'src/test-file'];
+      mockStaticAssets(...testAssets);
+
+      const repo = new SourceRepository(mockBlueprint, {
+        title: 'test-repo',
+      });
+
+      repo.copyStaticFiles({
+        from: 'src',
+        to: 'dest',
+      });
+
+      testAssets.forEach(path => {
+        expect(mockSourceFile).toHaveBeenCalledWith(repo, path.replace('src/', 'dest/'), TEST_FILE_CONTENTS);
+      });
+    });
+
+    it('substitutes file contents', () => {
+      const testAssets = ['src/.dotfile', 'src/test.ts', 'src/test-file'];
+      mockStaticAssets(...testAssets);
+
+      const repo = new SourceRepository(mockBlueprint, {
+        title: 'test-repo',
+      });
+
+      repo.copyStaticFiles({
+        substitute: {
+          test_var: 'test_val',
+        },
+      });
+
+      testAssets.forEach(path => {
+        expect(mockSourceFile).toHaveBeenCalledWith(repo, path, TEST_SUBSTITUTED_CONTENTS);
+      });
+    });
+  });
+});
+
+const TEST_FILE_CONTENTS = 'test file contents';
+const TEST_SUBSTITUTED_CONTENTS = 'test substituted contents';
+
+function mockStaticAssets(...paths: string[]): void {
+  mockSubstitutionAsset.findAll.mockImplementationOnce(() => {
+    return paths.map(path => {
+      return {
+        path: jest.fn().mockReturnValue(path),
+        content: jest.fn().mockReturnValue(TEST_FILE_CONTENTS),
+        toString: jest.fn().mockReturnValue(TEST_FILE_CONTENTS),
+        substitute: jest.fn().mockReturnValue(TEST_SUBSTITUTED_CONTENTS),
+      } as unknown as SubstitionAsset;
+    });
+  });
+}

--- a/packages/components/source-repositories/src/repository.ts
+++ b/packages/components/source-repositories/src/repository.ts
@@ -61,7 +61,11 @@ export class SourceRepository extends Component {
      */
     substitute?: { [key: string]: string };
   }) {
-    const from = path.join('', options?.from || '');
+    let from = options?.from ? path.join('', options?.from) : '';
+    if (from === '.') {
+      from = '';
+    }
+
     const to = options?.to || '';
 
     let fromGlob: string | undefined = undefined;


### PR DESCRIPTION
copyStaticFiles would mangle files with .'s in their name when copying from the root of static-assets.

### Issue

#474 

### Description

When `options.from` is undefined, `path.join('', options?.from || '')` evaluates to `.`, which we were later replacing in the destination path. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
