### PR TITLE
feat(secrets): add reference property

### DIFF
--- a/packages/components/secrets/src/secret-component.ts
+++ b/packages/components/secrets/src/secret-component.ts
@@ -17,11 +17,13 @@ const getHashedEntropy = (length: number, str: string) => hash(str).slice(2, 2 +
 export class Secret extends Component {
   name: string;
   description?: string;
+  reference: string;
 
   constructor(blueprint: Blueprint, secret: SecretDefinition) {
     super(blueprint);
     this.name = secret.name;
     this.description = secret.description;
+    this.reference = '${Secrets.' + this.name + '}';
 
     const nameRegex = /^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$/;
 
@@ -59,7 +61,7 @@ export class Secret extends Component {
       new YamlFile(blueprint, `secrets/${shortName}-${getHashedEntropy(5, shortName)}.yaml`, {
         readonly: false,
         marker: false,
-        obj: secret,
+        obj: { name: this.name, description: this.description },
       });
     }
   }


### PR DESCRIPTION
### Issue

The reference property will allow blueprint authors to easily reference secrets in workflows created in the blueprint. [Example](https://github.com/aws/codecatalyst-blueprints/wiki/Component:-Secrets#example-referencing-a-secret-in-a-workflow)

Issue number, if available, prefixed with "#"

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
