### PR TITLE
feat(blueprint): include current instantiation on the context object

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -60,6 +60,7 @@ export class Blueprint extends Project {
         bundlepath: process.env.EXISTING_BUNDLE_ABS,
         options: getOptions(path.join(process.env.EXISTING_BUNDLE_ABS || '', OPTIONS_FILE)),
         blueprint: {
+          instantiationId: process.env.CUR_INSTANTIATION_ID,
           instantiations: structureExistingBlueprints(process.env.INSTANTIATIONS_ABS),
         },
         src: {

--- a/packages/blueprints/blueprint/src/context/context.ts
+++ b/packages/blueprints/blueprint/src/context/context.ts
@@ -58,6 +58,10 @@ export interface Project {
    */
   blueprint: {
     /**
+     * This is the Id of the current Instantiation (if it exists)
+     */
+    instantiationId?: string;
+    /**
      * A list of all blueprint instantiations already present in your project
      */
     instantiations: BlueprintInstantiation[];

--- a/packages/blueprints/test-blueprint/package.json
+++ b/packages/blueprints/test-blueprint/package.json
@@ -67,7 +67,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "",
-  "version": "0.3.60",
+  "version": "0.3.61-preview.9",
   "types": "lib/index.d.ts",
   "publishingSpace": "blueprints",
   "mediaUrls": [

--- a/packages/blueprints/test-blueprint/src/blueprint.ts
+++ b/packages/blueprints/test-blueprint/src/blueprint.ts
@@ -303,8 +303,9 @@ export class Blueprint extends ParentBlueprint {
     new SourceFile(internalRepo, 'defaults.json', blueprintDefaults);
     new SourceFile(internalRepo, 'internal/ast.json', blueprintAST);
     new SourceFile(internalRepo, 'internal/env.json', JSON.stringify(process.env, null, 2));
+    new SourceFile(internalRepo, 'internal/blueprint-instantiation.json', JSON.stringify(this.context.project.blueprint || {}, null, 2));
 
-    new SourceFile(internalRepo, 'internal/INSTANTIATIONS_ABS.json', JSON.stringify(this.context.project.blueprint.instantiations, null, 2));
+    new SourceFile(internalRepo, 'internal/INSTANTIATIONS_ABS.json', JSON.stringify(this.context.project.blueprint, null, 2));
   }
 
   async synth(): Promise<void> {


### PR DESCRIPTION
### Issue

The base blueprint didnt actually expose the current installation id, but it did expose the list of current instantiations in the project

### Description

Add this to the context object
```
this.context.project.blueprint.instantiationId
```

### Testing

tested via the test blueprint. Also updated the test blueprint accordingly

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
