### PR TITLE
feat: add durable storage

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -41,8 +41,9 @@ export class Blueprint extends Project {
     });
 
     const OPTIONS_FILE = 'options.json';
+    const rootDir = path.resolve(this.outdir);
     this.context = {
-      rootDir: path.resolve(this.outdir),
+      rootDir,
       spaceName: process.env.CONTEXT_SPACENAME,
       environmentId: process.env.CONTEXT_ENVIRONMENTID,
       branchName: process.env.BRANCH_NAME,
@@ -77,6 +78,8 @@ export class Blueprint extends Project {
           findAll: (_options?: TraversalOptions) => traverse(this.context.project.bundlepath, _options),
         },
       },
+      durableStoragePath:
+        process.env.DURABLE_STORAGE_ABS && fs.existsSync(process.env.DURABLE_STORAGE_ABS) ? process.env.DURABLE_STORAGE_ABS : rootDir,
     };
 
     for (const component of this.components) {

--- a/packages/blueprints/blueprint/src/context/context.ts
+++ b/packages/blueprints/blueprint/src/context/context.ts
@@ -112,4 +112,14 @@ export interface Context {
   readonly npmConfiguration: NpmConfiguration;
   readonly package: PackageConfiguration;
   readonly project: Project;
+  /**
+   * Durable storage that is persisted between synthesis executions.
+   *
+   * This location is suitable for storing artifacts that are computationally exepensive to create and
+   * do not change between synthesis executions.
+   *
+   * If the underlying synthesis engine does not support durable storage then this value will be the
+   * same as `rootDir`.
+   */
+  readonly durableStoragePath: string;
 }


### PR DESCRIPTION
### Description

expose a durable storage path on the context that the author can use to persist computationally expensive resources between synthesis executions

### Testing

local synth

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
