### PR TITLE
feat(blueprint): allow overridden instantiation description

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -113,6 +113,13 @@ export class Blueprint extends Project {
     this.strategies[bundlepath] = strategies;
   }
 
+  setInstantiation(configurableOptions: { description: string }) {
+    const INSTANTIATION_FILE = 'instantiation.json';
+    const instantiationRecordPath = path.join(this.outdir, INSTANTIATION_FILE);
+    fs.mkdirSync(path.dirname(instantiationRecordPath), { recursive: true });
+    fs.writeFileSync(instantiationRecordPath, JSON.stringify(configurableOptions, null, 2));
+  }
+
   getResynthStrategies(bundlepath: string): Strategy[] {
     return (this.strategies || {})[bundlepath] || [];
   }

--- a/packages/blueprints/test-blueprint/package.json
+++ b/packages/blueprints/test-blueprint/package.json
@@ -68,7 +68,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "",
-  "version": "0.3.63",
+  "version": "0.3.64-preview.1",
   "types": "lib/index.d.ts",
   "publishingSpace": "blueprints",
   "mediaUrls": [

--- a/packages/blueprints/test-blueprint/src/blueprint.ts
+++ b/packages/blueprints/test-blueprint/src/blueprint.ts
@@ -300,6 +300,10 @@ export class Blueprint extends ParentBlueprint {
       to: 'subdirectory/in/my/repo',
     });
 
+    this.setInstantiation({
+      description: 'This is a overridden description',
+    });
+
     new SourceFile(internalRepo, 'blueprint.d.ts', blueprintInterface);
     new SourceFile(internalRepo, 'defaults.json', blueprintDefaults);
     new SourceFile(internalRepo, 'internal/ast.json', blueprintAST);


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

```
    this.setInstantiation({
      description: 'This is a overridden description',
    });

```

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
