### PR TITLE
fix: broken blueprint build workflow

### DIFF
--- a/packages/blueprints/blueprint-builder/src/blueprint.ts
+++ b/packages/blueprints/blueprint-builder/src/blueprint.ts
@@ -155,6 +155,7 @@ export class Blueprint extends ParentBlueprint {
         'typescript',
         `@amazon-codecatalyst/blueprint-util.projen-blueprint@${projenBlueprintPackage.version}`,
         `@amazon-codecatalyst/blueprint-util.cli@${cliPackage.version}`,
+        'fast-xml-parser'
       ],
       keywords: [...(options.advancedSettings?.tags || ['<<tag>>'])],
       homepage: '',
@@ -191,7 +192,7 @@ export class Blueprint extends ParentBlueprint {
               '@amazon-codecatalyst/blueprint-component.dev-environments',
               '@amazon-codecatalyst/blueprint-component.environments',
             ],
-            devDeps: ['ts-node@^10', 'typescript', '@amazon-codecatalyst/blueprint-util.projen-blueprint', '@amazon-codecatalyst/blueprint-util.cli'],
+            devDeps: ['ts-node@^10', 'typescript', '@amazon-codecatalyst/blueprint-util.projen-blueprint', '@amazon-codecatalyst/blueprint-util.cli', 'fast-xml-parser'],
           },
           null,
           2,


### PR DESCRIPTION
### Description

blueprint builder workflow is broken
```
blueprint build-ast ./lib/blueprint.d.ts --outdir ./lib/
node:internal/modules/cjs/loader:1031
throw err;
^

Error: Cannot find module 'fast-xml-parser'
```
### Testing

synth and build, testing on a project using blueprint builder in integ 
### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
