### PR TITLE
fix(launch): add cleanup exclusion for source

### DIFF
--- a/packages/blueprints/launch-blueprint/src/blueprint.ts
+++ b/packages/blueprints/launch-blueprint/src/blueprint.ts
@@ -168,6 +168,7 @@ export class Blueprint extends ParentBlueprint {
       }
     }
 
+    this.addExcludeFromCleanup(path.join(this.outdir, this.state.repository.title, '**'));
     super.synth();
   }
 }


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

* add a glob to skip cleanup for the cloned source repo
  * the cleanup function in the parent synth call removes any projen synthesized files

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
