### PR TITLE
fix(blueprint-cli): update bundle plugin to only consider ts and js

### DIFF
--- a/packages/utils/blueprint-cli/src/synth-drivers/cache.ts
+++ b/packages/utils/blueprint-cli/src/synth-drivers/cache.ts
@@ -56,7 +56,7 @@ const fsLinkerPlugin = {
       cp.execSync('rm -rf ./lib/externals');
     });
 
-    build.onLoad({ filter: /.*/ }, ({ path: filePath }) => {
+    build.onLoad({ filter: /\.(t|j)s/ }, ({ path: filePath }) => {
       if (filePath.match(nodeModulesRegex)) {
         const pathSegments = filePath.split('node_modules/');
         let segments = pathSegments[pathSegments.length - 1].split('/');


### PR DESCRIPTION
This PR constrains the list of files for the `fsLinkerPlugin` from all files to only `ts|js` files.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
