### PR TITLE
fix(chatbot): skip access logging in opt-in regions

### DIFF
--- a/packages/blueprints/gen-ai-chatbot/static-assets/chatbot-genai-cdk/lib/constructs/frontend.ts
+++ b/packages/blueprints/gen-ai-chatbot/static-assets/chatbot-genai-cdk/lib/constructs/frontend.ts
@@ -15,7 +15,7 @@ import { Auth } from "./auth";
 import { Idp } from "../utils/identity-provider";
 
 export interface FrontendProps {
-  readonly accessLogBucket: IBucket;
+  readonly accessLogBucket?: IBucket;
   readonly webAclId: string;
   readonly assetBucket: {
     prefix: string;
@@ -70,7 +70,7 @@ export class Frontend extends Construct {
           responsePagePath: "/",
         },
       ],
-      loggingConfig: {
+      loggingConfig: props.accessLogBucket && {
         bucket: props.accessLogBucket,
         prefix: "Frontend/",
       },

--- a/packages/blueprints/gen-ai-chatbot/static-assets/chatbot-genai-cdk/lib/utils/constants.ts
+++ b/packages/blueprints/gen-ai-chatbot/static-assets/chatbot-genai-cdk/lib/utils/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * CloudFront does not support access log delivery in the following regions
+ * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#access-logs-choosing-s3-bucket
+ */
+export const CF_SKIP_ACCESS_LOGGING_REGIONS = [
+  'af-south-1',
+  'ap-east-1',
+  'ap-south-2',
+  'ap-southeast-3',
+  'ap-southeast-4',
+  'ca-west-1',
+  'eu-south-1',
+  'eu-south-2',
+  'eu-central-2',
+  'il-central-1',
+  'me-central-1',
+];


### PR DESCRIPTION
### Issue

#541 

### Description

* skip access logging if the application is deployed to an opt-in region due to CloudFront support

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
