### PR TITLE
Fixing cleanup procedure for GenAI Blueprint.

### DIFF
--- a/packages/components/workflows/src/actions/action-cfn-cleanup.ts
+++ b/packages/components/workflows/src/actions/action-cfn-cleanup.ts
@@ -34,7 +34,7 @@ export const cfnCleanupSteps = (stackName: string, region: string, options?: { b
       region === 'us-east-1' ? '' : '--create-bucket-configuration LocationConstraint=$region'
     } || true`,
     'echo \'Update the cloudformation stack and wait for the status to no longer be "UPDATE_IN_PROGRESS" , ignoring the case when it needs not be updated.\'',
-    'aws s3 cp ./updated-template-$stack_name.json s3://$cfn_template_upload_bucket/updated-template-$stack_name.json',
+    'aws s3 cp ./updated-template-$stack_name.json s3://$cfn_template_upload_bucket/updated-template-$stack_name.json --region $region',
     'aws cloudformation update-stack --stack-name $stack_name --region $region --template-url https://s3.amazonaws.com/$cfn_template_upload_bucket/updated-template-$stack_name.json --capabilities CAPABILITY_NAMED_IAM || true',
     'timeout 300 bash -c \'while true; do status=$(aws cloudformation describe-stacks --stack-name "$stack_name" --region $region --query "Stacks[0].StackStatus" --output text); if [[ "$status" == "UPDATE_IN_PROGRESS" ]]; then sleep 10; else break; fi; done\'',
     "echo 'Store the list of associated S3 buckets and Elastic Container Registries'",


### PR DESCRIPTION
Adding missing region parameter in bucket cleaning procedure. Fixing the cleanup prcoedure

### Issue

https://github.com/aws/codecatalyst-blueprints/issues/541 Fixing point 3. of this issue.

### Description

Add option --region $region to s3 command in bucket

### Testing

Testend in eu-south-1 for cleanup.

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
