### PR TITLE
fix: exclude synth assets from cleanup

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -219,6 +219,11 @@ export class Blueprint extends Project {
   throwSynthesisError(error: BlueprintSynthesisError) {
     throw error;
   }
+
+  override synth(): void {
+    this.addExcludeFromCleanup(path.join(this.outdir, '**'));
+    super.synth();
+  }
 }
 
 export enum BlueprintSynthesisErrorTypes {


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

* exclude projen-generated static assets and non-source files from projen cleanup, which happens after the bundle is generated

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
