### PR TITLE
fix(blueprint): preserve file modes during resynth

### DIFF
--- a/packages/blueprints/blueprint/src/resynthesis/context-file.ts
+++ b/packages/blueprints/blueprint/src/resynthesis/context-file.ts
@@ -84,3 +84,7 @@ export function createContextFile(bundlepath: string, resourcePrefix: string, re
   }
   return undefined;
 }
+
+export function getAbsoluteContextFilePath(bundlepath: string, resourcePrefix: string, contextFile: ContextFile): string {
+  return path.join(bundlepath, resourcePrefix, contextFile.repositoryName, contextFile.path);
+}


### PR DESCRIPTION
Preserves the file mode of existing files during resynth.

### Issue

Issue number, if available, prefixed with "#"

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
