### PR TITLE
feat(blueprint): add UI selectors for option schemas

### DIFF
--- a/packages/blueprints/blueprint/src/blueprint.ts
+++ b/packages/blueprints/blueprint/src/blueprint.ts
@@ -80,6 +80,7 @@ export class Blueprint extends Project {
       },
       durableStoragePath:
         process.env.DURABLE_STORAGE_ABS && fs.existsSync(process.env.DURABLE_STORAGE_ABS) ? process.env.DURABLE_STORAGE_ABS : rootDir,
+      wizardOptionsPath: process.env.WIZARD_OPTIONS_ABS ?? path.join(rootDir, 'options'),
     };
 
     for (const component of this.components) {

--- a/packages/blueprints/blueprint/src/context/context.ts
+++ b/packages/blueprints/blueprint/src/context/context.ts
@@ -122,4 +122,9 @@ export interface Context {
    * same as `rootDir`.
    */
   readonly durableStoragePath: string;
+
+  /**
+   * Folder that contains dynamic wizard options that can be loaded at synthesis time.
+   */
+  readonly wizardOptionsPath: string;
 }

--- a/packages/blueprints/blueprint/src/index.ts
+++ b/packages/blueprints/blueprint/src/index.ts
@@ -10,6 +10,7 @@ export * from './ui-selectors/multiselect';
 export * from './ui-selectors/selector';
 export * from './ui-selectors/tuple';
 export * from './ui-selectors/dynamic-element';
+export * from './ui-selectors/options-schemas';
 
 import defaults_ from './defaults.json';
 export const defaults = defaults_;

--- a/packages/blueprints/blueprint/src/ui-selectors/options-schemas.ts
+++ b/packages/blueprints/blueprint/src/ui-selectors/options-schemas.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Component } from 'projen';
+import { DynamicKVInput } from './dynamic-kv-input';
+import { Blueprint } from '../blueprint';
+
+/**
+ * This represents an options schema based on DynamicKVInput types
+ */
+export type KVSchema = DynamicKVInput[];
+
+/**
+ * This represents all wizard supported schemas.
+ */
+export type OptionsSchemaType = KVSchema;
+
+/**
+ * This represents a section of the wizard that can be dynamically rendered from a schema provided by the synthesis process.
+ */
+export type OptionsSchemaDefinition<
+  // @ts-ignore:next-line value is never read
+  Identifier extends string,
+  // @ts-ignore:next-line value is never read
+  SchemaType extends OptionsSchemaType,
+  ReturnType extends any = any,
+> = ReturnType | undefined;
+
+/**
+ * This component can be used to define a schema with a given identifier.
+ */
+export class OptionsSchema<T extends OptionsSchemaType> extends Component {
+  constructor(protected readonly blueprint: Blueprint, protected readonly identifier: string, protected readonly schema: T) {
+    super(blueprint);
+  }
+
+  synthesize(): void {
+    if (!fs.existsSync(this.blueprint.context.wizardOptionsPath)) {
+      fs.mkdirSync(this.blueprint.context.wizardOptionsPath);
+    }
+
+    fs.writeFileSync(path.join(this.blueprint.context.wizardOptionsPath, this.identifier), JSON.stringify(this.schema));
+  }
+}

--- a/packages/utils/blueprint-cli/src/ast/parser/handle-declaration.ts
+++ b/packages/utils/blueprint-cli/src/ast/parser/handle-declaration.ts
@@ -9,7 +9,7 @@ const isOptional = (property): boolean => {
 export const handleArrayType = (property, path: string): Node => {
   const node: Node = {
     kind: property.type?.kind,
-    type: property.type?.elementType?.kind,
+    type: property.type?.elementType?.kind ?? property.elementType?.kind,
     name: property.name?.escapedText,
     optional: isOptional(property),
     jsDoc: extractJsdoc(property.jsDoc),
@@ -18,7 +18,7 @@ export const handleArrayType = (property, path: string): Node => {
 
   node.members = [
     {
-      ...convertToNode(property.type?.elementType, node.path),
+      ...convertToNode(property.type?.elementType ?? property.elementType, node.path),
       jsDoc: node.jsDoc,
     },
   ];


### PR DESCRIPTION
### Issue

N/A

### Description

This change implements dynamic `option schemas`.  Option schemas are a new type which allow the blueprint wizard to load sections of the wizard from synthesis.  This approach allows a blueprint itself, to control what options are shown in the wizard.  

To accomplish this, we introduce several new types:

`OptionsSchema<T>`:  Used to declare and register a new options schema.  For now, schemas can be defined using the existing `DynamicKVInput` type.  For example:
```
new OptionsSchema(this, 'my-options', [{
  key: 'region',
  value: 'us-east-1',
}, {
  key: 'mode',
  value: 'automatic',
}]
```

`OptionsSchemaDefinition<Identifier extends string, SchemaType extends OptionsSchemaType, ReturnType extends any = any> = ReturnType?`: Used to declare that a section of the wizard should be loaded dynamically.   The `Identifier` must match the schema identifier declared when instantiation an `OptionsSchema` (i.e. `my-options` from the example above).  For example:
```
export interface Options extends ParentOptions {
   embeddedParameters: OptionsSchemaDefinition<'my-options', KVSchema, { key: string, value: string }[]>;
}
```


### Testing

Local testing using a consuming blueprint.

### Additional context

Based on customer demand, we plan on releasing support for additional schemas, such as [react-jsonschema](https://github.com/rjsf-team/react-jsonschema-form).  For schema support requests, please provide feedback through issues.

This change also includes an update to the AST parser to support inline array types that do not have a formal type.  This is required to support the example `OptionsSchemaDefinition` above.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
