### PR TITLE
feat: set the default merge resolution strategy to prefer proposed

### DIFF
--- a/packages/blueprints/blueprint-builder/src/blueprint.ts
+++ b/packages/blueprints/blueprint-builder/src/blueprint.ts
@@ -114,6 +114,11 @@ export class Blueprint extends ParentBlueprint {
     this.repository = repository;
     this.repository.setResynthStrategies([
       {
+        identifier: 'resolve_merge_conflicts',
+        strategy: MergeStrategies.preferProposed,
+        globs: ['**/**'],
+      },
+      {
         identifier: 'never_update_sample_code',
         strategy: MergeStrategies.neverUpdate,
         globs: ['static-assets/**', 'src/**'],
@@ -192,7 +197,13 @@ export class Blueprint extends ParentBlueprint {
               '@amazon-codecatalyst/blueprint-component.dev-environments',
               '@amazon-codecatalyst/blueprint-component.environments',
             ],
-            devDeps: ['ts-node@^10', 'typescript', '@amazon-codecatalyst/blueprint-util.projen-blueprint', '@amazon-codecatalyst/blueprint-util.cli', 'fast-xml-parser'],
+            devDeps: [
+              'ts-node@^10',
+              'typescript',
+              '@amazon-codecatalyst/blueprint-util.projen-blueprint',
+              '@amazon-codecatalyst/blueprint-util.cli',
+              'fast-xml-parser',
+            ],
           },
           null,
           2,


### PR DESCRIPTION
### Issue

Updates to the base blueprint often result in annoying and not really needed merge conflicts. Typically the merge conflicts can just be resolved to the new stuff anyways.

### Description

This PR updates the default merge resolution strategy to prefer proposed for the blueprint builder. Depending on how this goes, it might make sense to make this the default for all blueprints.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
