### PR TITLE
fix: QOL improvement that defaults the merge strategy of blueprints to prefer-new

### DIFF
--- a/packages/blueprints/blueprint/src/resynthesis/merge-strategies/match.ts
+++ b/packages/blueprints/blueprint/src/resynthesis/merge-strategies/match.ts
@@ -4,7 +4,7 @@ import { Strategy } from './models';
 import { Ownership } from '../ownership';
 import { matchesGlob } from '../walk-files';
 
-export const FALLBACK_STRATEGY = MergeStrategies.threeWayMerge;
+export const FALLBACK_STRATEGY = MergeStrategies.preferProposed;
 export const FALLBACK_STRATEGY_ID = `FALLBACK_${FALLBACK_STRATEGY.name}`;
 
 export function match(sourceCodePath: string, strategies: { [bundlepath: string]: Strategy[] }): Strategy {


### PR DESCRIPTION
### Issue

Blueprints use three way merge as the default merge strategy. This is kinda annoying in practice because it causes various merge conflicts where there arent meant to be merge conflicts. Or does other annoying things like creating full page merge conflicts on linter errors. 

### Description

This PR changes the default behavior to be three way merge BUT with a default preference towards the newer code. Customers can still overwrite this by building their own merge strategy or applying one of the existing strategies on the repo construct.



### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
