### PR TITLE
fix(gen-ai-chatbot): change name to llm playground

### DIFF
--- a/packages/blueprints/gen-ai-chatbot/.projenrc.ts
+++ b/packages/blueprints/gen-ai-chatbot/.projenrc.ts
@@ -5,9 +5,8 @@ const project = new ProjenBlueprint({
   authorName: 'Amazon Web Services',
   publishingOrganization: 'blueprints',
   packageName: '@amazon-codecatalyst/blueprints.gen-ai-chatbot',
-  displayName: 'Bedrock GenAI Chatbot',
-  description:
-    'Builds a secure, log-in protected LLM playground that can be customized to your data. Use this blueprint to build and deploy your own chatbot.',
+  displayName: 'LLM Playground',
+  description: 'Create your own private LLM playground in minutes with code you can instantly customize and deploy.',
   name: 'gen-ai-chatbot',
   defaultReleaseBranch: 'main',
   npmAccess: NpmAccess.PUBLIC,
@@ -36,7 +35,7 @@ const project = new ProjenBlueprint({
   ],
 
   devDeps: ['ts-node', 'typescript', '@amazon-codecatalyst/blueprint-util.projen-blueprint', '@amazon-codecatalyst/blueprint-util.cli'],
-  keywords: ['genai', 'bedrock', 'chatbot', 'blueprint-publisher', 'external-blueprint', 'blueprint'],
+  keywords: ['log-in-protected', 'private', 'genai', 'bedrock', 'chatbot', 'blueprint-publisher', 'external-blueprint', 'blueprint'],
   homepage: '',
 });
 

--- a/packages/blueprints/gen-ai-chatbot/package.json
+++ b/packages/blueprints/gen-ai-chatbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amazon-codecatalyst/blueprints.gen-ai-chatbot",
-  "description": "Builds a secure, log-in protected LLM playground that can be customized to your data. Use this blueprint to build and deploy your own chatbot.",
+  "description": "Create your own private LLM playground in minutes with code you can instantly customize and deploy.",
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",
@@ -69,7 +69,9 @@
     "blueprint-publisher",
     "chatbot",
     "external-blueprint",
-    "genai"
+    "genai",
+    "log-in-protected",
+    "private"
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
@@ -80,7 +82,7 @@
   "version": "0.3.132",
   "types": "lib/index.d.ts",
   "publishingSpace": "blueprints",
-  "displayName": "Bedrock GenAI Chatbot",
+  "displayName": "LLM Playground",
   "files": [
     "static-assets",
     "lib"


### PR DESCRIPTION
### Issue

Updates the display name of the Gen-AI chatbot

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
