### PR TITLE
fix(workflows): add missing compute types

### DIFF
--- a/packages/components/workflows/src/workflow/compute.ts
+++ b/packages/components/workflows/src/workflow/compute.ts
@@ -13,6 +13,10 @@ export enum ComputeType {
 export enum ComputeFleet {
   LINUX_X86_64_LARGE = 'Linux.x86-64.Large',
   LINUX_X86_64_XLARGE = 'Linux.x86-64.XLarge',
+  LINUX_X86_64_2XLARGE = 'Linux.x86-64.2XLarge',
+  LINUX_ARM64_LARGE = 'Linux.Arm64.Large',
+  LINUX_ARM64_XLARGE = 'Linux.Arm64.XLarge',
+  LINUX_ARM64_2XLARGE = 'Linux.Arm64.2XLarge',
 }
 
 export function addGenericCompute(


### PR DESCRIPTION
Add missing compute types to the enum.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
