### PR TITLE
fix(blueprint-builder): fix to resynth strategies when converting to a BP

### DIFF
--- a/packages/blueprints/blueprint-builder/package.json
+++ b/packages/blueprints/blueprint-builder/package.json
@@ -71,7 +71,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "homepage": "https://aws.amazon.com/",
-  "version": "0.3.140",
+  "version": "0.3.141-preview.1",
   "types": "lib/index.d.ts",
   "publishingSpace": "blueprints",
   "mediaUrls": [

--- a/packages/blueprints/blueprint-builder/src/blueprint.ts
+++ b/packages/blueprints/blueprint-builder/src/blueprint.ts
@@ -166,6 +166,13 @@ export class Blueprint extends ParentBlueprint {
       this.repository.copyStaticFiles({
         from: 'converted-blueprint',
       });
+      this.repository.setResynthStrategies([
+        {
+          identifier: 'inital_conversion',
+          strategy: (_commonAncestorFile, _existingFile, proposedFile) => proposedFile,
+          globs: ['**/**'],
+        },
+      ]);
     } else {
       /**
        * Otherwise use the standard static assets
@@ -174,28 +181,14 @@ export class Blueprint extends ParentBlueprint {
         from: 'standard-static-assets',
         to: 'static-assets',
       });
+      this.setStandardResynthStrategies();
     }
-
-    this.setStandardResynthStrategies();
   }
 
   /**
    * This is the standard way we deal with resynthesis
    */
   setStandardResynthStrategies() {
-    if (this.isBlueprintConversion) {
-      console.log('THIS IS A BLUEPRINT CONVERSION. FORCING OVERWRITE');
-      this.repository.setResynthStrategies([
-        {
-          identifier: 'inital_conversion',
-          strategy: MergeStrategies.alwaysUpdate,
-          globs: ['**/**'],
-        },
-      ]);
-      return;
-    } else {
-    }
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const neverUpdateFiles = ['static-assets/**', 'src/**', 'README.md'];
     this.repository.setResynthStrategies([


### PR DESCRIPTION
### Issue

Currently we dont apply the correct proposed strat when converting a BP

### Description

What does this implement? Explain your changes.

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
