### PR TITLE
chore: set token type for workflow bearer tokens

### DIFF
--- a/packages/utils/blueprint-cli/src/publish/codecatalyst-authentication.ts
+++ b/packages/utils/blueprint-cli/src/publish/codecatalyst-authentication.ts
@@ -20,9 +20,13 @@ export function generateHeaders(authentication: CodeCatalystAuthentication, iden
     }
     return headers;
   } else {
-    return {
+    const headers = {
       authorization: authentication.token,
     };
+    if (authentication.type == 'workflowtoken') {
+      headers['Access-Token-Type'] = 'acsm';
+    }
+    return headers;
   }
 }
 


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

* set the access token type to acsm for workflow bearer tokens

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
