### PR TITLE
fix(gen-ai-chatbot): update CDK version used in workflow

### DIFF
--- a/packages/blueprints/gen-ai-chatbot/src/workflows.ts
+++ b/packages/blueprints/gen-ai-chatbot/src/workflows.ts
@@ -3,7 +3,7 @@ import { WorkflowBuilder, convertToWorkflowEnvironment } from '@amazon-codecatal
 import { Blueprint as ParentBlueprint } from '@amazon-codecatalyst/blueprints.blueprint';
 import { Options } from './blueprint';
 
-const cdkVersion = '2.132.0';
+const cdkVersion = '2.155.0';
 
 /**
  * Models used by the chatbot


### PR DESCRIPTION
### Issue

Issue number, if available, prefixed with "#"

### Description

Updates the CDK version used by the gen-ai-chatbot blueprint to the latest (2.155.0).

### Testing

How was this change tested?

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
