### PR TITLE
fix: use latest cdk version

### DIFF
--- a/packages/blueprints/gen-ai-chatbot/src/workflows.ts
+++ b/packages/blueprints/gen-ai-chatbot/src/workflows.ts
@@ -3,7 +3,7 @@ import { WorkflowBuilder, convertToWorkflowEnvironment } from '@amazon-codecatal
 import { Blueprint as ParentBlueprint } from '@amazon-codecatalyst/blueprints.blueprint';
 import { Options } from './blueprint';
 
-const cdkVersion = '2.160.0';
+const cdkVersion = 'latest';
 
 /**
  * Models used by the chatbot


### PR DESCRIPTION
### Description

using 'latest' as cdk version for CDKDeployAction so it won't break when it becomes to old for the latest cdk version

### Testing

published a preview project and created it and validated the workflow ran successfully.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
