### PR TITLE
fix: update builder blueprint workflow build action image

### DIFF
--- a/packages/blueprints/blueprint-builder/src/build-release-workflow.ts
+++ b/packages/blueprints/blueprint-builder/src/build-release-workflow.ts
@@ -47,7 +47,7 @@ export function buildReleaseWorkflow(workflow: WorkflowBuilder, options?: { incl
     steps: ["if $IS_RELEASE_COMMIT; then  echo 'This is a release commit, skipping'; else chmod +x release.sh && ./release.sh; fi"],
     container: {
       Registry: 'CODECATALYST',
-      Image: 'CodeCatalystLinux_x86_64:2022_11',
+      Image: 'CodeCatalystLinux_x86_64:2024_03',
     },
   });
 


### PR DESCRIPTION
### Issue

https://t.corp.amazon.com/P186073024

### Description
```
error @aws-sdk/types@3.723.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.20.2"
```

### Testing

tested in the console

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
