### PR TITLE
docs(tests): fix wrong case path in usage docstring

### DIFF
--- a/packages/blueprints/gen-ai-chatbot/static-assets/chatbot-genai-components/backend/python/tests/test_embedding/test_embed.py
+++ b/packages/blueprints/gen-ai-chatbot/static-assets/chatbot-genai-components/backend/python/tests/test_embedding/test_embed.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     ```
     cd backend
     docker build -f embedding.Dockerfile -t embedding .
-    docker run -it -v $(pwd)/tests:/src/tests embedding /src/tests/embedding/test_embed.py
+    docker run -it -v $(pwd)/tests:/src/tests embedding /src/tests/test_embedding/test_embed.py
     ```
     """
     unittest.main()


### PR DESCRIPTION
### Issue

Wrong path of spec in usage docstring of `test_embed.py`.

### Description

This PR aims to fix docstring of how to run test case of embedding.

### Testing

Run the command and verify it works correctly.

### Additional context

Add any other context about the PR here.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
